### PR TITLE
`HttpResponse` クラスのリファクタ

### DIFF
--- a/srcs/Config/Parser.cpp
+++ b/srcs/Config/Parser.cpp
@@ -1,20 +1,5 @@
 #include "Parser.hpp"
 
-namespace {
-std::string UIntToString(size_t num) {
-  std::ostringstream oss;
-
-  oss << num;
-  return oss.str();
-}
-
-std::string ConfigErrMessage(const std::string &msg, const Token &tkn) {
-  size_t lineNum = tkn.GetLine() + 1;
-  return msg + " `" + tkn.GetData() + "` :" + UIntToString(lineNum) +
-         " line Error";
-}
-}  // namespace
-
 Parser::Parser(const Lexer &lexer) : tkns_(lexer.GetTokens()) {
   server_directive_case_["listen"] = &Parser::StoreListen;
   server_directive_case_["client_max_body_size"] = &Parser::StoreClientBodySize;
@@ -253,6 +238,13 @@ void Parser::SetTokenIfEmpty(std::string *str, const Token &tkn,
 ConfigErrException::~ConfigErrException() {}
 std::string ConfigErrException::msg() const throw() { return err_msg_; }
 ConfigErrException::ConfigErrException(std::string msg, const Token &tkn)
-    : err_msg_(ConfigErrMessage(msg, tkn)) {}
+    : err_msg_(ConfigErrException::ConfigErrMessage(msg, tkn)) {}
 
 ConfigErrException::ConfigErrException(std::string msg) : err_msg_(msg) {}
+
+std::string ConfigErrException::ConfigErrMessage(const std::string &msg,
+                                                 const Token &tkn) {
+  size_t lineNum = tkn.GetLine() + 1;
+  return msg + " `" + tkn.GetData() + "` :" + utils::UIntToString(lineNum) +
+         " line Error";
+}

--- a/srcs/Config/Parser.hpp
+++ b/srcs/Config/Parser.hpp
@@ -78,6 +78,8 @@ class ConfigErrException {
   explicit ConfigErrException(std::string msg);
   ~ConfigErrException();
   std::string msg() const throw();
+
+  static std::string ConfigErrMessage(const std::string &msg, const Token &tkn);
 };
 
 #endif  // SRCS_CONFIG_PARSER_HPP_

--- a/srcs/Server/HttpResponse.cpp
+++ b/srcs/Server/HttpResponse.cpp
@@ -38,7 +38,13 @@ int HttpResponse::GetStatusCode() const { return this->statusCode_; }
 
 std::string const &HttpResponse::GetBody() const { return this->body_; }
 
-std::string HttpResponse::GetRequestLine() const {
+/*
+HTTP start-line: https://httpwg.org/specs/rfc9112.html#message.format
+
+  start-line     = request-line / status-line
+  status-line = HTTP-version SP status-code SP [ reason-phrase ]
+*/
+std::string HttpResponse::GetStatusLine() const {
   return this->version_ + " " + utils::Itoa(this->statusCode_) + " " +
          this->GetStatusMessage() + kCRLF;
 }
@@ -78,10 +84,18 @@ std::string HttpResponse::GetStatusMessage() const {
   }
 }
 
+/*
+HTTP message: https://httpwg.org/specs/rfc9112.html#message.format
+
+  HTTP-message   = start-line CRLF
+                   *( field-line CRLF )
+                   CRLF
+                   [ message-body ]
+*/
 std::vector<std::string> HttpResponse::GetResponse() const {
   std::vector<std::string> response;
 
-  response.push_back(this->GetRequestLine());
+  response.push_back(this->GetStatusLine());
 
   std::vector<std::string> headers = this->GetResponseHeaders();
   response.insert(response.end(), headers.begin(), headers.end());

--- a/srcs/Server/HttpResponse.hpp
+++ b/srcs/Server/HttpResponse.hpp
@@ -21,7 +21,7 @@ class HttpResponse {
 
   int GetStatusCode() const;
   std::string const &GetBody() const;
-  std::string GetRequestLine() const;
+  std::string GetStatusLine() const;
   std::vector<std::string> GetResponse() const;
   void SetHttpResponse200();
   std::vector<std::string> GetResponseHeaders() const;

--- a/srcs/Server/HttpResponse.hpp
+++ b/srcs/Server/HttpResponse.hpp
@@ -1,11 +1,14 @@
 #ifndef SRCS_SERVER_HTTPRESPONSE_HPP_
 #define SRCS_SERVER_HTTPRESPONSE_HPP_
+#include <map>
 #include <string>
 #include <utility>
 #include <vector>
 
 class HttpResponse {
  public:
+  typedef std::map<std::string, std::string> HttpHeaders;
+
   HttpResponse();
   HttpResponse(HttpResponse const &other);
   HttpResponse &operator=(HttpResponse const &other);
@@ -21,16 +24,15 @@ class HttpResponse {
   std::string GetRequestLine() const;
   std::vector<std::string> GetResponse() const;
   void SetHttpResponse200();
+  std::string GetStatusMessage() const;
+  std::vector<std::string> GetResponseHeaders() const;
 
  private:
   static const char kCRLF[3];
   int statusCode_;
-  std::vector<std::pair<std::string, std::string> > headers_;
+  std::map<std::string, std::string> headers_;
   std::string version_;
   std::string body_;
-
-  std::string GetStatusMessage() const;
-  std::vector<std::string> GetResponseHeader() const;
 };
 
 #endif  // SRCS_SERVER_HTTPRESPONSE_HPP_

--- a/srcs/Server/HttpResponse.hpp
+++ b/srcs/Server/HttpResponse.hpp
@@ -24,7 +24,6 @@ class HttpResponse {
   std::string GetRequestLine() const;
   std::vector<std::string> GetResponse() const;
   void SetHttpResponse200();
-  std::string GetStatusMessage() const;
   std::vector<std::string> GetResponseHeaders() const;
 
  private:
@@ -33,6 +32,8 @@ class HttpResponse {
   std::map<std::string, std::string> headers_;
   std::string version_;
   std::string body_;
+
+  std::string GetStatusMessage() const;
 };
 
 #endif  // SRCS_SERVER_HTTPRESPONSE_HPP_

--- a/srcs/Server/Server.cpp
+++ b/srcs/Server/Server.cpp
@@ -60,6 +60,8 @@ void Server::AcceptNewConnections(epoll_event *ev) {
   Event *connsock = new Connecting(conn_fd, sock->GetContext());
   AddEventToMonitored(connsock, EPOLLIN);
 }
+
+// [FIXME]
 void Server::ReceiveRequest(epoll_event *ev) {
   // ConnectingEvent *sock =
   // dynamic_cast<ConnectingEvent *>(Events_[ev->data.fd]);

--- a/srcs/Server/Server.cpp
+++ b/srcs/Server/Server.cpp
@@ -63,13 +63,13 @@ void Server::AcceptNewConnections(epoll_event *ev) {
 
 // [FIXME]
 void Server::ReceiveRequest(epoll_event *ev) {
-  // ConnectingEvent *sock =
-  // dynamic_cast<ConnectingEvent *>(Events_[ev->data.fd]);
-  // parsed_request pr = sock->GetParsedRequest();
-  // read_stat st = receive_request_.ReadHttpRequest(sock->GetFd(),&pr);
-  // sock->SetParsedRequest(pr);
-  // if(st == )
-  (void)ev;
+  Connecting *connecting_event =
+      dynamic_cast<Connecting *>(this->events_[ev->data.fd]);
+  parsed_request pr = connecting_event->GetParsedRequest();
+  read_stat st =
+      receive_request_.ReadHttpRequest(connecting_event->GetFd(), &pr);
+  (void)st;
+  connecting_event->SetParsedRequest(pr);
 }
 void Server::AddEventToMonitored(Event *sock, uint32_t event_flag) {
   events_.insert(std::make_pair(sock->GetFd(), sock));

--- a/srcs/Server/Server.hpp
+++ b/srcs/Server/Server.hpp
@@ -32,7 +32,8 @@ class Server {
   void ExecEvents(epoll_event *ev);
   void AcceptNewConnections(epoll_event *ev);
   void ConnectingEvent(epoll_event *ev);
-  static void ReceiveRequest(epoll_event *ev);
+  void AddMonitorToRequest(epoll_event *fd);
+  void ReceiveRequest(epoll_event *ev);
   void SendResponse(epoll_event *ev);
   int WriteToClientFd(const int connfd);
   Server();

--- a/srcs/Utils/Utils.cpp
+++ b/srcs/Utils/Utils.cpp
@@ -1,5 +1,7 @@
 #include "Utils.hpp"
 
+#include <sstream>
+
 namespace utils {
 
 std::string Itoa(int n) {
@@ -44,5 +46,12 @@ std::vector<std::string> SplitWithMultipleSpecifier(
   }
   if (!item.empty()) elements.push_back(item);
   return elements;
+}
+
+std::string UIntToString(size_t num) {
+  std::ostringstream oss;
+
+  oss << num;
+  return oss.str();
 }
 }  // namespace utils

--- a/srcs/Utils/Utils.hpp
+++ b/srcs/Utils/Utils.hpp
@@ -12,6 +12,7 @@ int Atoi(const std::string &s);
 long StrToLong(const std::string &str);
 std::vector<std::string> SplitWithMultipleSpecifier(
     const std::string &str, const std::string &separators);
+std::string UIntToString(size_t num);
 }  // namespace utils
 
 #endif  // SRCS_UTILS_UTILS_HPP_

--- a/tests/unit_test/HttpResponseTest.cc
+++ b/tests/unit_test/HttpResponseTest.cc
@@ -65,7 +65,7 @@ TEST(HttpResponseTest_Default, RequestLine) {
   res.SetStatusCode(200);
   std::string expected = "HTTP/1.1 200 OK\r\n";
 
-  EXPECT_EQ(expected, res.GetRequestLine());
+  EXPECT_EQ(expected, res.GetStatusLine());
 }
 
 TEST(HttpResponseTest_Default, RequestLine_400) {
@@ -73,7 +73,7 @@ TEST(HttpResponseTest_Default, RequestLine_400) {
   res.SetStatusCode(400);
   std::string expected = "HTTP/1.1 400 Bad Request\r\n";
 
-  EXPECT_EQ(expected, res.GetRequestLine());
+  EXPECT_EQ(expected, res.GetStatusLine());
 }
 
 TEST(HttpResponseTest_Default, RequestLine_500) {
@@ -81,7 +81,7 @@ TEST(HttpResponseTest_Default, RequestLine_500) {
   res.SetStatusCode(500);
   std::string expected = "HTTP/1.1 500 Internal Server Error\r\n";
 
-  EXPECT_EQ(expected, res.GetRequestLine());
+  EXPECT_EQ(expected, res.GetStatusLine());
 }
 
 TEST(HttpResponseTest_Default, GetResponse) {

--- a/tests/unit_test/HttpResponseTest.cc
+++ b/tests/unit_test/HttpResponseTest.cc
@@ -71,8 +71,8 @@ TEST(HttpResponseTest_Default, RequestLine) {
 TEST(HttpResponseTest_Default, RequestLine_400) {
   HttpResponse res;
   res.SetStatusCode(400);
-  std::string expected = "HTTP/1.1 400 Bad Request\r\n"; 
-  
+  std::string expected = "HTTP/1.1 400 Bad Request\r\n";
+
   EXPECT_EQ(expected, res.GetRequestLine());
 }
 
@@ -84,3 +84,35 @@ TEST(HttpResponseTest_Default, RequestLine_500) {
   EXPECT_EQ(expected, res.GetRequestLine());
 }
 
+TEST(HttpResponseTest_Default, GetResponse) {
+  HttpResponse http_response;
+  http_response.SetStatusCode(200);
+  http_response.SetBody("Hello World");
+  http_response.SetHeader("Content-Length", http_response.GetBody().size());
+
+  std::vector<std::string> expected = {
+      "HTTP/1.1 200 OK\r\n", "Content-Length: 11\r\n", "\r\n", "Hello World"};
+
+  std::vector<std::string> res = http_response.GetResponse();
+  for (int i = 0; i < expected.size(); i++) {
+    EXPECT_EQ(expected[i], res[i]);
+  }
+}
+
+TEST(HttpResponseTest_Default, GetResponse_400) {
+  HttpResponse http_response;
+  http_response.SetStatusCode(400);
+  http_response.SetBody("");
+  http_response.SetHeader("Content-Length", http_response.GetBody().size());
+
+  std::vector<std::string> expected = {
+      "HTTP/1.1 400 Bad Request\r\n",
+      "Content-Length: 0\r\n",
+      "\r\n",
+  };
+
+  std::vector<std::string> res = http_response.GetResponse();
+  for (int i = 0; i < expected.size(); i++) {
+    EXPECT_EQ(expected[i], res[i]);
+  }
+}

--- a/tests/unit_test/HttpResponseTest.cc
+++ b/tests/unit_test/HttpResponseTest.cc
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include "HttpResponse.hpp"
+
+TEST(HttpResponseTest_Default, StatusCode) {
+  HttpResponse res;
+  res.SetStatusCode(200);
+  EXPECT_EQ(200, res.GetStatusCode());
+}
+
+TEST(HttpResponseTest_Default, Body) {
+  HttpResponse res;
+  std::string body = "Hello World";
+  res.SetBody(body);
+  EXPECT_EQ(body, res.GetBody());
+}
+
+TEST(HttpResponseTest_Default, Header) {
+  HttpResponse res;
+  std::string key = "Content-Type";
+  std::string value = "text/html";
+  res.SetHeader(key, value);
+
+  std::vector<std::string> response_headers = res.GetResponseHeaders();
+  std::string expected = "Content-Type: text/html\r\n";
+  EXPECT_EQ(expected, response_headers[0]);
+}
+
+TEST(HttpResponseTest_Default, Header_Multiple) {
+  HttpResponse res;
+  std::string key = "Content-Type";
+  std::string value = "text/html";
+  res.SetHeader(key, value);
+
+  std::string key2 = "Content-Length";
+  std::string value2 = "100";
+  res.SetHeader(key2, value2);
+
+  std::vector<std::string> response_headers = res.GetResponseHeaders();
+
+  std::vector<std::string> expected;
+  expected.push_back("Content-Length: 100\r\n");
+  expected.push_back("Content-Type: text/html\r\n");
+
+  EXPECT_EQ(expected, response_headers);
+}
+
+TEST(HttpResponseTest_Default, Header_Duplicated) {
+  HttpResponse res;
+  std::string key = "Content-Type";
+  std::string value = "text/html";
+  res.SetHeader(key, value);
+
+  try {
+    res.SetHeader(key, value);
+
+    FAIL() << "Expected std::logic_error";
+  } catch (std::logic_error &e) {
+    EXPECT_STREQ("key already exists", e.what());
+  }
+}
+
+TEST(HttpResponseTest_Default, RequestLine) {
+  HttpResponse res;
+  res.SetStatusCode(200);
+  std::string expected = "HTTP/1.1 200 OK\r\n";
+
+  EXPECT_EQ(expected, res.GetRequestLine());
+}
+
+TEST(HttpResponseTest_Default, RequestLine_400) {
+  HttpResponse res;
+  res.SetStatusCode(400);
+  std::string expected = "HTTP/1.1 400 Bad Request\r\n"; 
+  
+  EXPECT_EQ(expected, res.GetRequestLine());
+}
+
+TEST(HttpResponseTest_Default, RequestLine_500) {
+  HttpResponse res;
+  res.SetStatusCode(500);
+  std::string expected = "HTTP/1.1 500 Internal Server Error\r\n";
+
+  EXPECT_EQ(expected, res.GetRequestLine());
+}
+


### PR DESCRIPTION
## 関連するissue

Closes  #48


##  概要

- 不要なファイル(`srcs/Server/ParseRequestMessage.*pp`)を削除した
- `HttpResponse`クラスのテストを追加した
- RFC9112の用語の定義をもとに、GetRequestLine -> GetStatusLineに変更