### PR TITLE
Googele C++ Style Guideにenum以外従うようにclang-tidyの設定を変更した

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,88 +1,137 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.bzero,readability-convert-member-functions-to-static,readability-const-return-type,readability-identifier-naming,readability-make-member-function-const,readability-non-const-parameter,readability-qualified-auto,readability-redundant-control-flow,readability-redundant-member-init,readability-else-after-return,readability-implicit-bool-conversion,readability-simplify-boolean-expr,readability-static-accessed-through-instance,cppcoreguidelines-init-variables,cppcoreguidelines-virtual-class-destructor,cppcoreguidelines-prefer-member-initializer,llvm-include-order,misc-definitions-in-headers,misc-unused-parameters,modernize-redundant-void-arg,modernize-use-bool-literals,bugprone-copy-constructor-init,bugprone-virtual-near-miss,portability-restrict-system-includes,performance-for-range-copy,performance-inefficient-vector-operation,performance-type-promotion-in-math-fn-tidy'
-WarningsAsErrors: ''
-HeaderFilterRegex: '.*'
+Checks: "clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-security.insecureAPI.bzero,readability-convert-member-functions-to-static,readability-const-return-type,readability-identifier-naming,readability-make-member-function-const,readability-non-const-parameter,readability-qualified-auto,readability-redundant-control-flow,readability-redundant-member-init,readability-else-after-return,readability-implicit-bool-conversion,readability-simplify-boolean-expr,readability-static-accessed-through-instance,cppcoreguidelines-init-variables,cppcoreguidelines-virtual-class-destructor,cppcoreguidelines-prefer-member-initializer,llvm-include-order,misc-definitions-in-headers,misc-unused-parameters,modernize-redundant-void-arg,modernize-use-bool-literals,bugprone-copy-constructor-init,bugprone-virtual-near-miss,portability-restrict-system-includes,performance-for-range-copy,performance-inefficient-vector-operation,performance-type-promotion-in-math-fn-tidy"
+WarningsAsErrors: ""
+HeaderFilterRegex: ".*"
 AnalyzeTemporaryDtors: false
-FormatStyle:     none
+FormatStyle: none
 CheckOptions:
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
-  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
-    value:           '0'
-  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
-    value:           '0'
-  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
-    value:           '1'
-  - key:             cppcoreguidelines-init-variables.IncludeStyle
-    value:           llvm
-  - key:             cppcoreguidelines-init-variables.MathHeader
-    value:           math.h
-  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value:           '1'
-  - key:             google-readability-braces-around-statements.ShortStatementLines
-    value:           '1'
-  - key:             google-readability-function-size.StatementThreshold
-    value:           '800'
-  - key:             google-readability-namespace-comments.ShortNamespaceLines
-    value:           '10'
-  - key:             google-readability-namespace-comments.SpacesBeforeComments
-    value:           '2'
-  - key:             llvm-else-after-return.WarnOnConditionVariables
-    value:           '0'
-  - key:             llvm-else-after-return.WarnOnUnfixable
-    value:           '0'
-  - key:             llvm-qualified-auto.AddConstToQualified
-    value:           '0'
-  - key:             misc-definitions-in-headers.HeaderFileExtensions
-    value:           ';h;hh;hpp;hxx'
-  - key:             misc-definitions-in-headers.UseHeaderFileExtension
-    value:           'true'
-  - key:             misc-unused-parameters.StrictMode
-    value:           'false'
-  - key:             modernize-loop-convert.MaxCopySize
-    value:           '16'
-  - key:             modernize-loop-convert.MinConfidence
-    value:           reasonable
-  - key:             modernize-loop-convert.NamingStyle
-    value:           CamelCase
-  - key:             modernize-pass-by-value.IncludeStyle
-    value:           llvm
-  - key:             modernize-replace-auto-ptr.IncludeStyle
-    value:           llvm
-  - key:             modernize-use-bool-literals.IgnoreMacros
-    value:           'true'
-  - key:             performance-for-range-copy.AllowedTypes
-    value:           ''
-  - key:             performance-for-range-copy.WarnOnAllAutoCopies
-    value:           'false'
-  - key:             performance-inefficient-vector-operation.EnableProto
-    value:           'false'
-  - key:             performance-inefficient-vector-operation.VectorLikeClasses
-    value:           '::std::vector'
-  - key:             portability-restrict-system-includes.Includes
-    value:           '*'
-  - key:             readability-else-after-return.WarnOnConditionVariables
-    value:           'true'
-  - key:             readability-else-after-return.WarnOnUnfixable
-    value:           'true'
-  - key:             readability-identifier-naming.AggressiveDependentMemberLookup
-    value:           'false'
-  - key:             readability-identifier-naming.IgnoreFailedSplit
-    value:           'false'
-  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
-    value:           'false'
-  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
-    value:           'false'
-  - key:             readability-implicit-bool-conversion.AllowPointerConditions
-    value:           'false'
-  - key:             readability-qualified-auto.AddConstToQualified
-    value:           'true'
-  - key:             readability-redundant-member-init.IgnoreBaseInCopyConstructors
-    value:           'false'
-  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
-    value:           'false'
-  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
-    value:           'false'
-  - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
-    value:           '3'
-...
+  - key: cert-dcl16-c.NewSuffixes
+    value: "L;LL;LU;LLU"
+  - key: cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value: "0"
+  - key: cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value: "0"
+  - key: cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value: "1"
+  - key: cppcoreguidelines-init-variables.IncludeStyle
+    value: llvm
+  - key: cppcoreguidelines-init-variables.MathHeader
+    value: math.h
+  - key: cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: "1"
+  - key: google-readability-braces-around-statements.ShortStatementLines
+    value: "1"
+  - key: google-readability-function-size.StatementThreshold
+    value: "800"
+  - key: google-readability-namespace-comments.ShortNamespaceLines
+    value: "10"
+  - key: google-readability-namespace-comments.SpacesBeforeComments
+    value: "2"
+  - key: llvm-else-after-return.WarnOnConditionVariables
+    value: "0"
+  - key: llvm-else-after-return.WarnOnUnfixable
+    value: "0"
+  - key: llvm-qualified-auto.AddConstToQualified
+    value: "0"
+  - key: misc-definitions-in-headers.HeaderFileExtensions
+    value: ";h;hh;hpp;hxx"
+  - key: misc-definitions-in-headers.UseHeaderFileExtension
+    value: "true"
+  - key: misc-unused-parameters.StrictMode
+    value: "false"
+  - key: modernize-loop-convert.MaxCopySize
+    value: "16"
+  - key: modernize-loop-convert.MinConfidence
+    value: reasonable
+  - key: modernize-loop-convert.NamingStyle
+    value: CamelCase
+  - key: modernize-pass-by-value.IncludeStyle
+    value: llvm
+  - key: modernize-replace-auto-ptr.IncludeStyle
+    value: llvm
+  - key: modernize-use-bool-literals.IgnoreMacros
+    value: "true"
+  - key: performance-for-range-copy.AllowedTypes
+    value: ""
+  - key: performance-for-range-copy.WarnOnAllAutoCopies
+    value: "false"
+  - key: performance-inefficient-vector-operation.EnableProto
+    value: "false"
+  - key: performance-inefficient-vector-operation.VectorLikeClasses
+    value: "::std::vector"
+  - key: portability-restrict-system-includes.Includes
+    value: "*"
+  - key: readability-else-after-return.WarnOnConditionVariables
+    value: "true"
+  - key: readability-else-after-return.WarnOnUnfixable
+    value: "true"
+  - key: readability-identifier-naming.AggressiveDependentMemberLookup
+    value: "false"
+  - key: readability-identifier-naming.IgnoreFailedSplit
+    value: "false"
+  - key: readability-identifier-naming.IgnoreMainLikeFunctions
+    value: "false"
+  - key: readability-implicit-bool-conversion.AllowIntegerConditions
+    value: "false"
+  - key: readability-implicit-bool-conversion.AllowPointerConditions
+    value: "false"
+  - key: readability-qualified-auto.AddConstToQualified
+    value: "true"
+  - key: readability-redundant-member-init.IgnoreBaseInCopyConstructors
+    value: "false"
+  - key: readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value: "false"
+  - key: readability-simplify-boolean-expr.ChainedConditionalReturn
+    value: "false"
+  - key: readability-static-accessed-through-instance.NameSpecifierNestingThreshold
+    value: "3"
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: CamelCase
+  - key: readability-identifier-naming.ConstexprVariablePrefix
+    value: k
+  # - key: readability-identifier-naming.EnumCase
+  #   value: CamelCase
+  # - key: readability-identifier-naming.EnumConstantCase
+  #   value: CamelCase
+  # - key: readability-identifier-naming.EnumConstantPrefix
+  #   value: k
+  - key: readability-identifier-naming.FunctionCase
+    value: CamelCase
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k
+  - key: readability-identifier-naming.StaticConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.StaticConstantPrefix
+    value: k
+  - key: readability-identifier-naming.StaticVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.MacroDefinitionIgnoredRegexp
+    value: "^[A-Z]+(_[A-Z]+)*_$"
+  - key: readability-identifier-naming.MemberCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key: readability-identifier-naming.PublicMemberSuffix
+    value: ""
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.TypeAliasCase
+    value: CamelCase
+  - key: readability-identifier-naming.TypedefCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.IgnoreMainLikeFunctions
+    value: 1
+---
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -93,12 +93,12 @@ CheckOptions:
     value: CamelCase
   - key: readability-identifier-naming.ConstexprVariablePrefix
     value: k
-  # - key: readability-identifier-naming.EnumCase
-  #   value: CamelCase
-  # - key: readability-identifier-naming.EnumConstantCase
-  #   value: CamelCase
-  # - key: readability-identifier-naming.EnumConstantPrefix
-  #   value: k
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantPrefix
+    value: k
   - key: readability-identifier-naming.FunctionCase
     value: CamelCase
   - key: readability-identifier-naming.GlobalConstantCase

--- a/srcs/Config/Parser.cpp
+++ b/srcs/Config/Parser.cpp
@@ -9,8 +9,8 @@ std::string UIntToString(size_t num) {
 }
 
 std::string ConfigErrMessage(const std::string &msg, const Token &tkn) {
-  size_t lineNum = tkn.GetLine() + 1;
-  return msg + " `" + tkn.GetData() + "` :" + UIntToString(lineNum) +
+  size_t line_num = tkn.GetLine() + 1;
+  return msg + " `" + tkn.GetData() + "` :" + UIntToString(line_num) +
          " line Error";
 }
 }  // namespace
@@ -84,7 +84,7 @@ std::string Parser::ParseListen(Token tkn) {
     listen_str = listen_str.substr(colon_pos + 1);
   }
   long listen = utils::StrToLong(listen_str);
-  if (kport_min > listen || listen > kport_max)
+  if (kPortMin > listen || listen > kPortMax)
     throw ConfigErrException("listen invalid value", tkn);
   return listen_str;
 }
@@ -128,7 +128,7 @@ void Parser::StoreErrorPage(ServerContext *sc) {
     ThrowExceptionIfMatch(next, "{}",
                           "invalid arguments in `error_page` directive");
     long err_num = utils::StrToLong(current.GetData().c_str());
-    if (err_num < kstatus_code_min || kstatus_code_max < err_num)
+    if (err_num < kStatusCodeMin || kStatusCodeMax < err_num)
       throw ConfigErrException(
           "error_page directive value must be between 300 and 599", current);
     sc->error_page.insert(std::make_pair(err_num, ""));
@@ -253,7 +253,7 @@ void Parser::SetTokenIfEmpty(std::string *str, const Token &tkn,
   *str = tkn.GetData();
 }
 ConfigErrException::~ConfigErrException() {}
-std::string ConfigErrException::msg() const throw() { return err_msg_; }
+std::string ConfigErrException::Msg() const throw() { return err_msg_; }
 ConfigErrException::ConfigErrException(std::string msg, const Token &tkn)
     : err_msg_(ConfigErrMessage(msg, tkn)) {}
 

--- a/srcs/Config/Parser.cpp
+++ b/srcs/Config/Parser.cpp
@@ -159,8 +159,8 @@ void Parser::StoreLocation(ServerContext *sc) {
 void Parser::StoreLimitExcept(LocationContext *lc) {
   Token tkn = tkns_.Next();
   do {
-    if (tkn.GetData() == "DELETE" || tkn.GetData() == "GET" ||
-        tkn.GetData() == "POST") {
+    if (tkn.GetData() == "kDelete" || tkn.GetData() == "kGet" ||
+        tkn.GetData() == "kPost") {
       if (lc->limit_except.find(tkn.GetData()) != lc->limit_except.end())
         throw ConfigErrException("`limit_except` directive is duplicate", tkn);
       lc->limit_except.insert(tkn.GetData());

--- a/srcs/Config/Parser.hpp
+++ b/srcs/Config/Parser.hpp
@@ -18,10 +18,10 @@
 #include "Utils.hpp"
 class Parser {
  private:
-  static const long kport_max = 65535;
-  static const long kport_min = 1;
-  static const long kstatus_code_min = 300;
-  static const long kstatus_code_max = 599;
+  static const long kPortMax = 65535;
+  static const long kPortMin = 1;
+  static const long kStatusCodeMin = 300;
+  static const long kStatusCodeMax = 599;
   std::vector<ServerContext> contexts_;
 
   TokenManager tkns_;
@@ -77,7 +77,7 @@ class ConfigErrException {
   ConfigErrException(std::string msg, const Token &tkn);
   explicit ConfigErrException(std::string msg);
   ~ConfigErrException();
-  std::string msg() const throw();
+  std::string Msg() const throw();
 };
 
 #endif  // SRCS_CONFIG_PARSER_HPP_

--- a/srcs/Main/main.cpp
+++ b/srcs/Main/main.cpp
@@ -12,7 +12,7 @@ int main(int ac, char **av) {
   } catch (std::runtime_error &e) {
     std::cout << e.what() << std::endl;
   } catch (ConfigErrException &e) {
-    std::cout << e.msg() << std::endl;
+    std::cout << e.Msg() << std::endl;
   }
   return 0;
 }

--- a/srcs/Server/Cgi.cpp
+++ b/srcs/Server/Cgi.cpp
@@ -1,5 +1,5 @@
 #include "Cgi.hpp"
-Cgi::Cgi(const ServerContext &context, const parsed_request &pr, method m)
+Cgi::Cgi(const ServerContext &context, const ParsedRequest &pr, method m)
     : Event(-1, context, CGI), method_(m) {
   // set up
   (void)pr;
@@ -170,13 +170,13 @@ void Cgi::Run() {
 // location
 // status
 
-static const char EncodeTable[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
-                                     '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+static const char kEncodeTable[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
+                                      '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
 bool IsSafe(char c) {
   return (std::isalnum(c) != 0) || c == '.' || c == '-' || c == '_' || c == '~';
 }
-static const char DecodeTable[128] = {
+static const char kDecodeTable[128] = {
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,
@@ -191,8 +191,8 @@ std::string Encode(const std::string &str) {
       encode += str[i];
     } else {
       encode += '%';
-      encode += EncodeTable[(str[i] & 0xf0) >> 4];
-      encode += EncodeTable[str[i] & 0x0f];
+      encode += kEncodeTable[(str[i] & 0xf0) >> 4];
+      encode += kEncodeTable[str[i] & 0x0f];
     }
   }
   return encode;
@@ -202,11 +202,11 @@ std::string Decode(const std::string &str) {
   for (size_t i = 0; i < str.size(); i++) {
     if (str[i] == '%') {
       if (str.size() <= i + 2 ||
-          DecodeTable[static_cast<unsigned char>(str[i + 1])] == -1 ||
-          DecodeTable[static_cast<unsigned char>(str[i + 2])] == -1)
+          kDecodeTable[static_cast<unsigned char>(str[i + 1])] == -1 ||
+          kDecodeTable[static_cast<unsigned char>(str[i + 2])] == -1)
         continue;
-      decode += (DecodeTable[static_cast<unsigned char>(str[i + 1])] << 4) +
-                DecodeTable[static_cast<unsigned char>(str[i + 2])];
+      decode += (kDecodeTable[static_cast<unsigned char>(str[i + 1])] << 4) +
+                kDecodeTable[static_cast<unsigned char>(str[i + 2])];
       i += 2;
     } else if (str[i] == '+') {
       decode += ' ';

--- a/srcs/Server/Cgi.cpp
+++ b/srcs/Server/Cgi.cpp
@@ -1,6 +1,6 @@
 #include "Cgi.hpp"
-Cgi::Cgi(const ServerContext &context, const ParsedRequest &pr, method m)
-    : Event(-1, context, CGI), method_(m) {
+Cgi::Cgi(const ServerContext &context, const ParsedRequest &pr, Method m)
+    : Event(-1, context, kCgi), method_(m) {
   // set up
   (void)pr;
   ParseArgv();
@@ -8,7 +8,7 @@ Cgi::Cgi(const ServerContext &context, const ParsedRequest &pr, method m)
   SetEnv();
   EnvMapToCharPtr();
   // post
-  // if(type == POST)
+  // if(type == kPost)
   // PipeIn();
   // else{
   PipeOut();
@@ -119,11 +119,11 @@ void Cgi::Fork() {
 // }
 // }
 void Cgi::Dup2() {
-  // if(type_ == GET){
+  // if(type_ == kGet){
   if (dup2(pipe_out_[1], STDOUT_FILENO) == -1)
     throw std::runtime_error("dup2 err");
   // }
-  // else if(type_ == POST){
+  // else if(type_ == kPost){
   // if(dup2(pipe_in_[0], STDIN_FILENO) == -1)
   // throw std::runtime_error("dup2 err");
   // }
@@ -131,7 +131,7 @@ void Cgi::Dup2() {
 void Cgi::Run() {
   Fork();
   if (chilid_process_ == 0) {
-    // if(type_ == GET)
+    // if(type_ == kGet)
     // close(pipe_out_[0]);
     // else
     close(pipe_out_[1]);
@@ -145,7 +145,7 @@ void Cgi::Run() {
   } else {
     DelPtr(env_ptr_);
     DelPtr(argv_ptr_);
-    // if(type_ == GET)
+    // if(type_ == kGet)
     // close(pipe_out_[1]);
     // else
     // close(pipe_out_[0]);

--- a/srcs/Server/Cgi.hpp
+++ b/srcs/Server/Cgi.hpp
@@ -47,7 +47,7 @@ class Cgi : public Event {
   static void DelPtr(char **ptr);
 
  public:
-  Cgi(const ServerContext &context, const parsed_request &pr, method m);
+  Cgi(const ServerContext &context, const ParsedRequest &pr, method m);
   ~Cgi();
   void Run();
   int GetOutFd() const;

--- a/srcs/Server/Cgi.hpp
+++ b/srcs/Server/Cgi.hpp
@@ -24,7 +24,7 @@ class Cgi : public Event {
   int pipe_in_[2];
   pid_t child_process_;
   std::string chunked_;
-  method method_;
+  Method method_;
 
   // CgiType type_;
   std::string pass_;
@@ -47,7 +47,7 @@ class Cgi : public Event {
   static void DelPtr(char **ptr);
 
  public:
-  Cgi(const ServerContext &context, const ParsedRequest &pr, method m);
+  Cgi(const ServerContext &context, const ParsedRequest &pr, Method m);
   ~Cgi();
   void Run();
   int GetOutFd() const;

--- a/srcs/Server/Connecting.cpp
+++ b/srcs/Server/Connecting.cpp
@@ -1,6 +1,6 @@
 #include "Connecting.hpp"
 Connecting::Connecting(const int fd, const ServerContext& context)
-    : Event(fd, context, CONNECTING) {}
+    : Event(fd, context, kConnecting) {}
 Connecting::~Connecting() {}
 
 ParsedRequest Connecting::GetParsedRequest() const { return pr_; }

--- a/srcs/Server/Connecting.cpp
+++ b/srcs/Server/Connecting.cpp
@@ -3,8 +3,8 @@ Connecting::Connecting(const int fd, const ServerContext& context)
     : Event(fd, context, CONNECTING) {}
 Connecting::~Connecting() {}
 
-parsed_request Connecting::GetParsedRequest() const { return pr_; }
-void Connecting::SetParsedRequest(const parsed_request& pr) { pr_ = pr; }
+ParsedRequest Connecting::GetParsedRequest() const { return pr_; }
+void Connecting::SetParsedRequest(const ParsedRequest& pr) { pr_ = pr; }
 read_stat Connecting::ReadRequest() {
   return (hr_.ReadHttpRequest(GetFd(), &pr_));
 }

--- a/srcs/Server/Connecting.cpp
+++ b/srcs/Server/Connecting.cpp
@@ -5,6 +5,6 @@ Connecting::~Connecting() {}
 
 ParsedRequest Connecting::GetParsedRequest() const { return pr_; }
 void Connecting::SetParsedRequest(const ParsedRequest& pr) { pr_ = pr; }
-read_stat Connecting::ReadRequest() {
+ReadStat Connecting::ReadRequest() {
   return (hr_.ReadHttpRequest(GetFd(), &pr_));
 }

--- a/srcs/Server/Connecting.hpp
+++ b/srcs/Server/Connecting.hpp
@@ -15,6 +15,6 @@ class Connecting : public Event {
   ~Connecting();
   ParsedRequest GetParsedRequest() const;
   void SetParsedRequest(const ParsedRequest& pr);
-  read_stat ReadRequest();
+  ReadStat ReadRequest();
 };
 #endif  // SRCS_SERVER_CONNECTING_HPP_

--- a/srcs/Server/Connecting.hpp
+++ b/srcs/Server/Connecting.hpp
@@ -8,13 +8,13 @@
 class Connecting : public Event {
  private:
   ReceiveHttpRequest hr_;
-  parsed_request pr_;
+  ParsedRequest pr_;
 
  public:
   Connecting(const int fd, const ServerContext& context);
   ~Connecting();
-  parsed_request GetParsedRequest() const;
-  void SetParsedRequest(const parsed_request& pr);
+  ParsedRequest GetParsedRequest() const;
+  void SetParsedRequest(const ParsedRequest& pr);
   read_stat ReadRequest();
 };
 #endif  // SRCS_SERVER_CONNECTING_HPP_

--- a/srcs/Server/Event.cpp
+++ b/srcs/Server/Event.cpp
@@ -13,8 +13,8 @@ ssize_t Event::Write(const char* str, size_t size) const {
   return written_size;
 }
 std::string Event::Read() const {
-  char buf[Kbuffer_size_];
-  ssize_t read_size = read(GetFd(), buf, Kbuffer_size_);
+  char buf[kBufferSize];
+  ssize_t read_size = read(GetFd(), buf, kBufferSize);
   if (read_size == -1) throw std::runtime_error("read err");
   buf[read_size] = '\0';
   std::string ret(buf);

--- a/srcs/Server/Event.hpp
+++ b/srcs/Server/Event.hpp
@@ -5,8 +5,8 @@
 
 #include "Fd.hpp"
 #include "ServerContext.hpp"
-enum EventType { LISTEN, CONNECTING, CGI };
-enum EventStatus { READ, WRITE, WAIT, DEL };
+enum EventType { kListen, kConnecting, kCgi };
+enum EventStatus { kRead, kWrite, kWait, kDel };
 class Event : public Fd {
  private:
   ServerContext context_;

--- a/srcs/Server/Event.hpp
+++ b/srcs/Server/Event.hpp
@@ -15,7 +15,7 @@ class Event : public Fd {
   Event& operator=(const Event& sock);
   Event();
   Event(const Event& sock);
-  static const int Kbuffer_size_ = 8192;
+  static const int kBufferSize = 8192;
 
  public:
   Event(const int fd, const ServerContext& context, const EventType type);

--- a/srcs/Server/Listen.cpp
+++ b/srcs/Server/Listen.cpp
@@ -28,7 +28,7 @@ int Listen::GenerateConnectableFd() {
   }
   freeaddrinfo(address_);
   if (current == NULL) throw std::runtime_error("socket bind err");
-  if (listen(listen_fd, klisten_max) > -1) {
+  if (listen(listen_fd, kListenMax) > -1) {
     throw std::runtime_error("listen err");
   }
   return listen_fd;

--- a/srcs/Server/Listen.hpp
+++ b/srcs/Server/Listen.hpp
@@ -17,7 +17,7 @@
 #include "ServerContext.hpp"
 class Listen {
  private:
-  static const int klisten_max = 1024;
+  static const int kListenMax = 1024;
   struct addrinfo hint_;
   struct addrinfo *address_;
   std::string host_;

--- a/srcs/Server/ListenEvent.cpp
+++ b/srcs/Server/ListenEvent.cpp
@@ -2,7 +2,7 @@
 
 #include <sys/socket.h>
 ListenEvent::ListenEvent(const int fd, const ServerContext& context)
-    : Event(fd, context, LISTEN) {}
+    : Event(fd, context, kListen) {}
 ListenEvent::~ListenEvent() {}
 int ListenEvent::Accept() {
   int conn = accept(GetFd(), NULL, NULL);

--- a/srcs/Server/ReceiveHttpRequest.cpp
+++ b/srcs/Server/ReceiveHttpRequest.cpp
@@ -77,7 +77,7 @@ method ConvertMethod(const std::string &method) {
   }
 }
 
-method InputHttpRequestLine(const std::string &line, parsed_request *pr) {
+method InputHttpRequestLine(const std::string &line, ParsedRequest *pr) {
   std::size_t pos = 0;
   std::size_t top = 0;
 
@@ -137,7 +137,7 @@ HEADER ParseRequestHeader(const std::string &header_line) {
 }
 
 read_stat ReceiveHttpRequest::ReadHttpRequest(const int &fd,
-                                              parsed_request *pr) {
+                                              ParsedRequest *pr) {
   size_t pos = 0;
   ssize_t read_ret = 0;
   char buf[BUFFER_SIZE];
@@ -186,7 +186,7 @@ read_stat ReceiveHttpRequest::ReadHttpRequest(const int &fd,
 }
 
 // void ReceiveHttpRequest::ShowParsedRequest(const int &fd) {
-//   parsed_request req = fd_data_.pr;
+//   ParsedRequest req = fd_data_.pr;
 //   const std::string me[9] = {"ERROR",   "CONNECT", "DELETE", "GET",  "HEAD",
 //                              "OPTIONS", "POST",    "PUT",    "TRACE"};
 

--- a/srcs/Server/ReceiveHttpRequest.cpp
+++ b/srcs/Server/ReceiveHttpRequest.cpp
@@ -1,7 +1,7 @@
 #include "ReceiveHttpRequest.hpp"
 ReceiveHttpRequest::ReceiveHttpRequest() {
-  fd_data_.s = UNREAD;
-  fd_data_.pr.m = ERROR;
+  fd_data_.s = kUnread;
+  fd_data_.pr.m = kError;
   fd_data_.pr.status_code = 0;
 }
 
@@ -46,7 +46,7 @@ static std::string TrimByPos(std::string *buf, const size_t &pos,
   return trim;
 }
 
-method ConvertMethod(const std::string &method) {
+Method ConvertMethod(const std::string &method) {
   int i = static_cast<int>(method == "CONNECT") |
           static_cast<int>(method == "DELETE") * 2 |
           static_cast<int>(method == "GET") * 3 |
@@ -57,27 +57,27 @@ method ConvertMethod(const std::string &method) {
           static_cast<int>(method == "TRACE") * 8;
   switch (i) {
     case 1:
-      return (CONNECT);
+      return (kConnect);
     case 2:
-      return (DELETE);
+      return (kDelete);
     case 3:
-      return (GET);
+      return (kGet);
     case 4:
-      return (HEAD);
+      return (kHead);
     case 5:
-      return (OPTIONS);
+      return (kOptions);
     case 6:
-      return (POST);
+      return (kPost);
     case 7:
-      return (PUT);
+      return (kPut);
     case 8:
-      return (TRACE);
+      return (kTrace);
     default:
-      return (ERROR);
+      return (kError);
   }
 }
 
-method InputHttpRequestLine(const std::string &line, ParsedRequest *pr) {
+Method InputHttpRequestLine(const std::string &line, ParsedRequest *pr) {
   std::size_t pos = 0;
   std::size_t top = 0;
 
@@ -143,51 +143,52 @@ ReadStat ReceiveHttpRequest::ReadHttpRequest(const int &fd, ParsedRequest *pr) {
 
   read_ret = read(fd, buf, BUFFER_SIZE);
   if (read_ret == -1) {
-    return READ_ERROR;
+    return kReadError;
   }
   buf[read_ret] = '\0';
   fd_data_.buf += buf;
-  if (fd_data_.s == UNREAD || fd_data_.s == WAIT_REQUEST) {
+  if (fd_data_.s == kUnread || fd_data_.s == kWaitRequest) {
     pos = fd_data_.buf.find(NL);
     if (std::string::npos != pos) {
       fd_data_.request_line = TrimByPos(&fd_data_.buf, pos, 2);
-      if (InputHttpRequestLine(fd_data_.request_line, &fd_data_.pr) == ERROR) {
-        fd_data_.s = ERROR_REQUEST;
+      if (InputHttpRequestLine(fd_data_.request_line, &fd_data_.pr) == kError) {
+        fd_data_.s = kErrorRequest;
       } else {
-        fd_data_.s = WAIT_HEADER;
+        fd_data_.s = kWaitHeader;
       }
     } else {
-      fd_data_.s = WAIT_REQUEST;
+      fd_data_.s = kWaitRequest;
       *pr = fd_data_.pr;
-      return WAIT_REQUEST;
+      return kWaitRequest;
     }
   }
 
-  if (fd_data_.s == WAIT_HEADER) {
+  if (fd_data_.s == kWaitHeader) {
     pos = fd_data_.buf.find(NLNL);
     if (std::string::npos != pos) {
       fd_data_.request_header = TrimByPos(&fd_data_.buf, pos, 4);
       fd_data_.pr.request_header = ParseRequestHeader(fd_data_.request_header);
-      fd_data_.s = WAIT_BODY;
+      fd_data_.s = kWaitBody;
     } else {
-      fd_data_.s = WAIT_HEADER;
+      fd_data_.s = kWaitHeader;
       *pr = fd_data_.pr;
-      return WAIT_HEADER;
+      return kWaitHeader;
     }
   }
 
-  if (fd_data_.s == WAIT_BODY) {
+  if (fd_data_.s == kWaitBody) {
     pos = fd_data_.buf.find(NL);
     fd_data_.pr.request_body = TrimByPos(&fd_data_.buf, pos, 2);
   }
   *pr = fd_data_.pr;
-  return READ_COMPLETE;
+  return kReadComplete;
 }
 
 // void ReceiveHttpRequest::ShowParsedRequest(const int &fd) {
 //   ParsedRequest req = fd_data_.pr;
-//   const std::string me[9] = {"ERROR",   "CONNECT", "DELETE", "GET",  "HEAD",
-//                              "OPTIONS", "POST",    "PUT",    "TRACE"};
+//   const std::string me[9] = {"kError",   "kConnect", "kDelete", "kGet",
+//   "kHead",
+//                              "kOptions", "kPost",    "kPut",    "kTrace"};
 
 //   std::cout << me[req.m] << std::endl;
 //   std::cout << req.request_path << std::endl;

--- a/srcs/Server/ReceiveHttpRequest.cpp
+++ b/srcs/Server/ReceiveHttpRequest.cpp
@@ -117,8 +117,8 @@ std::pair<std::string, std::string> SplitRequestHeaderLine(
   return std::make_pair(key, value);
 }
 
-HEADER ParseRequestHeader(const std::string &header_line) {
-  HEADER header;
+Header ParseRequestHeader(const std::string &header_line) {
+  Header header;
   size_t top = 0;
   size_t pos = 0;
   std::string trim;
@@ -136,8 +136,7 @@ HEADER ParseRequestHeader(const std::string &header_line) {
   return header;
 }
 
-read_stat ReceiveHttpRequest::ReadHttpRequest(const int &fd,
-                                              ParsedRequest *pr) {
+ReadStat ReceiveHttpRequest::ReadHttpRequest(const int &fd, ParsedRequest *pr) {
   size_t pos = 0;
   ssize_t read_ret = 0;
   char buf[BUFFER_SIZE];

--- a/srcs/Server/ReceiveHttpRequest.hpp
+++ b/srcs/Server/ReceiveHttpRequest.hpp
@@ -28,7 +28,7 @@ enum read_stat {
   READ_ERROR
 };
 
-struct parsed_request {
+struct ParsedRequest {
   method m;
   std::string version;
   int status_code;
@@ -37,25 +37,25 @@ struct parsed_request {
   std::string request_body;
 };
 
-struct httprequest_data {
+struct HttpRequestData {
   read_stat s;
   std::string buf;
   std::string request_line;
   std::string request_header;
   std::string message_body;
-  struct parsed_request pr;
+  struct ParsedRequest pr;
 };
 
 class ReceiveHttpRequest {
  private:
-  httprequest_data fd_data_;
+  HttpRequestData fd_data_;
 
  public:
   ReceiveHttpRequest();
   ReceiveHttpRequest(ReceiveHttpRequest const &other);
   ReceiveHttpRequest &operator=(ReceiveHttpRequest const &other);
   ~ReceiveHttpRequest();
-  read_stat ReadHttpRequest(const int &fd, parsed_request *pr);
+  read_stat ReadHttpRequest(const int &fd, ParsedRequest *pr);
   void ShowParsedRequest(const int &fd);
   std::string GetBuf();
 };

--- a/srcs/Server/ReceiveHttpRequest.hpp
+++ b/srcs/Server/ReceiveHttpRequest.hpp
@@ -12,11 +12,11 @@
 #define NLNL "\r\n\r\n"
 #define BUFFER_SIZE 8192
 
-typedef std::vector<std::pair<std::string, std::string> > HEADER;
+typedef std::vector<std::pair<std::string, std::string> > Header;
 
 enum method { ERROR, CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, TRACE };
 
-enum read_stat {
+enum ReadStat {
   UNREAD,
   WAIT_REQUEST,
   ERROR_REQUEST,
@@ -33,12 +33,12 @@ struct ParsedRequest {
   std::string version;
   int status_code;
   std::string request_path;
-  HEADER request_header;
+  Header request_header;
   std::string request_body;
 };
 
 struct HttpRequestData {
-  read_stat s;
+  ReadStat s;
   std::string buf;
   std::string request_line;
   std::string request_header;
@@ -55,7 +55,7 @@ class ReceiveHttpRequest {
   ReceiveHttpRequest(ReceiveHttpRequest const &other);
   ReceiveHttpRequest &operator=(ReceiveHttpRequest const &other);
   ~ReceiveHttpRequest();
-  read_stat ReadHttpRequest(const int &fd, ParsedRequest *pr);
+  ReadStat ReadHttpRequest(const int &fd, ParsedRequest *pr);
   void ShowParsedRequest(const int &fd);
   std::string GetBuf();
 };

--- a/srcs/Server/ReceiveHttpRequest.hpp
+++ b/srcs/Server/ReceiveHttpRequest.hpp
@@ -14,22 +14,32 @@
 
 typedef std::vector<std::pair<std::string, std::string> > Header;
 
-enum method { ERROR, CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, TRACE };
+enum Method {
+  kError,
+  kConnect,
+  kDelete,
+  kGet,
+  kHead,
+  kOptions,
+  kPost,
+  kPut,
+  kTrace
+};
 
 enum ReadStat {
-  UNREAD,
-  WAIT_REQUEST,
-  ERROR_REQUEST,
-  WAIT_HEADER,
-  ERROR_HEADER,
-  WAIT_BODY,
-  ERROR_BODY,
-  READ_COMPLETE,
-  READ_ERROR
+  kUnread,
+  kWaitRequest,
+  kErrorRequest,
+  kWaitHeader,
+  kErrorHeader,
+  kWaitBody,
+  kErrorBody,
+  kReadComplete,
+  kReadError
 };
 
 struct ParsedRequest {
-  method m;
+  Method m;
   std::string version;
   int status_code;
   std::string request_path;

--- a/srcs/Server/Server.cpp
+++ b/srcs/Server/Server.cpp
@@ -64,7 +64,7 @@ void Server::ReceiveRequest(epoll_event *ev) {
   // ConnectingEvent *sock =
   // dynamic_cast<ConnectingEvent *>(Events_[ev->data.fd]);
   // ParsedRequest pr = sock->GetParsedRequest();
-  // read_stat st = receive_request_.ReadHttpRequest(sock->GetFd(),&pr);
+  // ReadStat st = receive_request_.ReadHttpRequest(sock->GetFd(),&pr);
   // sock->SetParsedRequest(pr);
   // if(st == )
   (void)ev;

--- a/srcs/Server/Server.cpp
+++ b/srcs/Server/Server.cpp
@@ -63,7 +63,7 @@ void Server::AcceptNewConnections(epoll_event *ev) {
 void Server::ReceiveRequest(epoll_event *ev) {
   // ConnectingEvent *sock =
   // dynamic_cast<ConnectingEvent *>(Events_[ev->data.fd]);
-  // parsed_request pr = sock->GetParsedRequest();
+  // ParsedRequest pr = sock->GetParsedRequest();
   // read_stat st = receive_request_.ReadHttpRequest(sock->GetFd(),&pr);
   // sock->SetParsedRequest(pr);
   // if(st == )
@@ -78,9 +78,9 @@ void Server::AddEventToMonitored(Event *sock, uint32_t event_flag) {
 void Server::SendResponse(epoll_event *ev) {
   int status = 0;
   response_[ev->data.fd];
-  HttpResponse httpResponse;
-  httpResponse.SetHttpResponse200();
-  response_[ev->data.fd] = httpResponse.GetResponse();
+  HttpResponse http_response;
+  http_response.SetHttpResponse200();
+  response_[ev->data.fd] = http_response.GetResponse();
   if ((status = WriteToClientFd(ev->data.fd)) == kNotDoneYet) {
     (void)status;
     return;

--- a/srcs/Server/Server.cpp
+++ b/srcs/Server/Server.cpp
@@ -27,7 +27,7 @@ void Server::Run() {
     for (int i = 0; i < num_event; i++) {
       epoll_event ev = epoll_.FindEvent(i);
       ExecEvents(&ev);
-      if (events_[ev.data.fd]->GetEventStatus() == DEL)
+      if (events_[ev.data.fd]->GetEventStatus() == kDel)
         DelEvent(events_[ev.data.fd], &ev);
     }
   }
@@ -35,13 +35,13 @@ void Server::Run() {
 
 void Server::ExecEvents(epoll_event *ev) {
   switch (events_[ev->data.fd]->GetEventType()) {
-    case LISTEN:
+    case kListen:
       AcceptNewConnections(ev);
       break;
-    case CONNECTING:
+    case kConnecting:
       ConnectingEvent(ev);
       break;
-    case CGI:
+    case kCgi:
       CgiEvent(ev);
       break;
   }

--- a/srcs/Utils/Useful.hpp
+++ b/srcs/Utils/Useful.hpp
@@ -5,12 +5,4 @@
 #include <set>
 #include <string>
 #include <vector>
-#define string std::string
-#define cout std::cout
-#define endl std::endl
-#define cerr std::cerr
-#define flush std::flush
-#define vector std::vector
-#define map std::map
-#define set std::set
 #endif  // SRCS_UTILS_USEFUL_HPP_

--- a/tests/unit_test/ReceiveHttpRequest_test.cc
+++ b/tests/unit_test/ReceiveHttpRequest_test.cc
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 #define DIR "./text/ReceiveHttpRequest/"
 
-HEADER expected_full = {{"Host", "hoge.com"},
+Header expected_full = {{"Host", "hoge.com"},
                         {"Connection", "keep-alive"},
                         {"Content-Length", "38"},
                         {"Cache-Control", "max-age=0"},
@@ -33,7 +33,7 @@ void copy_fd(int dst, const char *src) {
   close(srcfd);
 }
 
-void compare_header(HEADER header, HEADER expected_header) {
+void compare_header(Header header, Header expected_header) {
   for (size_t i = 0; i < header.size(); i++) {
     EXPECT_EQ(header.at(i).first, expected_header.at(i).first);
     EXPECT_EQ(header.at(i).second, expected_header.at(i).second);
@@ -43,7 +43,7 @@ void compare_header(HEADER header, HEADER expected_header) {
 TEST(ReceiveHttpRequest, full) {
   ReceiveHttpRequest rhr;
   ParsedRequest pr;
-  read_stat rs;
+  ReadStat rs;
   int fd = open("./text/ReceiveHttpRequest/ReceiveHttpRequest.txt", O_RDWR);
   copy_fd(fd, "FullRequest");
   rs = rhr.ReadHttpRequest(fd, &pr);
@@ -60,7 +60,7 @@ TEST(ReceiveHttpRequest, full) {
 TEST(ReceiveHttpRequest, empty_then_full) {
   ReceiveHttpRequest rhr;
   ParsedRequest pr;
-  read_stat rs;
+  ReadStat rs;
 
   int fd = open("./text/ReceiveHttpRequest/ReceiveHttpRequest.txt",
                 O_RDWR | O_TRUNC);
@@ -85,7 +85,7 @@ TEST(ReceiveHttpRequest, empty_then_full) {
 TEST(ReceiveHttpRequest, only_request_line) {
   ReceiveHttpRequest rhr;
   ParsedRequest pr;
-  read_stat rs;
+  ReadStat rs;
   int fd = open("./text/ReceiveHttpRequest/ReceiveHttpRequest.txt",
                 O_RDWR | O_TRUNC);
 
@@ -102,7 +102,7 @@ TEST(ReceiveHttpRequest, only_request_line) {
 TEST(ReceiveHttpRequest, half_then_half) {
   ReceiveHttpRequest rhr;
   ParsedRequest pr;
-  read_stat rs;
+  ReadStat rs;
   int fd = open("./text/ReceiveHttpRequest/ReceiveHttpRequest.txt",
                 O_RDWR | O_TRUNC);
   copy_fd(fd, "HalfRequestLine");

--- a/tests/unit_test/ReceiveHttpRequest_test.cc
+++ b/tests/unit_test/ReceiveHttpRequest_test.cc
@@ -42,7 +42,7 @@ void compare_header(HEADER header, HEADER expected_header) {
 
 TEST(ReceiveHttpRequest, full) {
   ReceiveHttpRequest rhr;
-  parsed_request pr;
+  ParsedRequest pr;
   read_stat rs;
   int fd = open("./text/ReceiveHttpRequest/ReceiveHttpRequest.txt", O_RDWR);
   copy_fd(fd, "FullRequest");
@@ -59,7 +59,7 @@ TEST(ReceiveHttpRequest, full) {
 
 TEST(ReceiveHttpRequest, empty_then_full) {
   ReceiveHttpRequest rhr;
-  parsed_request pr;
+  ParsedRequest pr;
   read_stat rs;
 
   int fd = open("./text/ReceiveHttpRequest/ReceiveHttpRequest.txt",
@@ -84,7 +84,7 @@ TEST(ReceiveHttpRequest, empty_then_full) {
 
 TEST(ReceiveHttpRequest, only_request_line) {
   ReceiveHttpRequest rhr;
-  parsed_request pr;
+  ParsedRequest pr;
   read_stat rs;
   int fd = open("./text/ReceiveHttpRequest/ReceiveHttpRequest.txt",
                 O_RDWR | O_TRUNC);
@@ -101,7 +101,7 @@ TEST(ReceiveHttpRequest, only_request_line) {
 
 TEST(ReceiveHttpRequest, half_then_half) {
   ReceiveHttpRequest rhr;
-  parsed_request pr;
+  ParsedRequest pr;
   read_stat rs;
   int fd = open("./text/ReceiveHttpRequest/ReceiveHttpRequest.txt",
                 O_RDWR | O_TRUNC);

--- a/tests/unit_test/ReceiveHttpRequest_test.cc
+++ b/tests/unit_test/ReceiveHttpRequest_test.cc
@@ -48,8 +48,8 @@ TEST(ReceiveHttpRequest, full) {
   copy_fd(fd, "FullRequest");
   rs = rhr.ReadHttpRequest(fd, &pr);
 
-  EXPECT_EQ(READ_COMPLETE, rs);
-  EXPECT_EQ(POST, pr.m);
+  EXPECT_EQ(kReadComplete, rs);
+  EXPECT_EQ(kPost, pr.m);
   EXPECT_EQ("/search.html", pr.request_path);
   EXPECT_EQ("HTTP/1.1", pr.version);
   compare_header(pr.request_header, expected_full);
@@ -67,14 +67,14 @@ TEST(ReceiveHttpRequest, empty_then_full) {
   copy_fd(fd, "EmptyRequest");
   rs = rhr.ReadHttpRequest(fd, &pr);
 
-  EXPECT_EQ(WAIT_REQUEST, rs);
+  EXPECT_EQ(kWaitRequest, rs);
 
   copy_fd(fd, "FullRequest");
   rs = rhr.ReadHttpRequest(fd, &pr);
 
-  EXPECT_EQ(READ_COMPLETE, rs);
-  EXPECT_EQ(READ_COMPLETE, rs);
-  EXPECT_EQ(POST, pr.m);
+  EXPECT_EQ(kReadComplete, rs);
+  EXPECT_EQ(kReadComplete, rs);
+  EXPECT_EQ(kPost, pr.m);
   EXPECT_EQ("/search.html", pr.request_path);
   EXPECT_EQ("HTTP/1.1", pr.version);
   compare_header(pr.request_header, expected_full);
@@ -92,8 +92,8 @@ TEST(ReceiveHttpRequest, only_request_line) {
   copy_fd(fd, "OnlyRequestLine");
   rs = rhr.ReadHttpRequest(fd, &pr);
 
-  EXPECT_EQ(WAIT_HEADER, rs);
-  EXPECT_EQ(POST, pr.m);
+  EXPECT_EQ(kWaitHeader, rs);
+  EXPECT_EQ(kPost, pr.m);
   EXPECT_EQ("/search.html", pr.request_path);
   EXPECT_EQ("HTTP/1.1", pr.version);
   close(fd);
@@ -107,16 +107,16 @@ TEST(ReceiveHttpRequest, half_then_half) {
                 O_RDWR | O_TRUNC);
   copy_fd(fd, "HalfRequestLine");
   rs = rhr.ReadHttpRequest(fd, &pr);
-  EXPECT_EQ(WAIT_REQUEST, rs);
-  EXPECT_EQ(ERROR, pr.m);
+  EXPECT_EQ(kWaitRequest, rs);
+  EXPECT_EQ(kError, pr.m);
   EXPECT_EQ("", pr.request_path);
   EXPECT_EQ("", pr.version);
   EXPECT_EQ("POST /search.", rhr.GetBuf());
 
   copy_fd(fd, "HalfRequestLine2");
   rs = rhr.ReadHttpRequest(fd, &pr);
-  EXPECT_EQ(WAIT_HEADER, rs);
-  EXPECT_EQ(POST, pr.m);
+  EXPECT_EQ(kWaitHeader, rs);
+  EXPECT_EQ(kPost, pr.m);
   EXPECT_EQ("/search.html", pr.request_path);
   EXPECT_EQ("HTTP/1.1", pr.version);
   EXPECT_EQ("", rhr.GetBuf());

--- a/tests/unit_test/googletest-release-1.12.1/googletest/test/googletest-message-test.cc
+++ b/tests/unit_test/googletest-release-1.12.1/googletest/test/googletest-message-test.cc
@@ -54,7 +54,7 @@ TEST(MessageTest, CopyConstructor) {
 
 // Tests constructing a Message from a C-string.
 TEST(MessageTest, ConstructsFromCString) {
-  Message msg("Hello");
+  Message Msg("Hello");
   EXPECT_EQ("Hello", msg.GetString());
 }
 
@@ -144,7 +144,7 @@ TEST(MessageTest, GetString) {
 
 // Tests streaming a Message object to an ostream.
 TEST(MessageTest, StreamsToOStream) {
-  Message msg("Hello");
+  Message Msg("Hello");
   ::std::stringstream ss;
   ss << msg;
   EXPECT_EQ("Hello", testing::internal::StringStreamToString(&ss));


### PR DESCRIPTION
## 変更点

表題の通り
定数名・型名なども何らかのStyle Guideに従ったほうが扱いやすくなるかなと思い、変更しました


## 備考

https://google.github.io/styleguide/cppguide.html#Enumerator_Names

enumの例については、あまり見慣れない感じがしたので相談したいです

### Google C++ Style Guide (Enumerator Names)

#### OK

```c++
enum class UrlTableError {
  kOk = 0,
  kOutOfMemory,
  kMalformedInput,
};
```

#### NG

```c++
enum class AlternateUrlTableError {
  OK = 0,
  OUT_OF_MEMORY = 1,
  MALFORMED_INPUT = 2,
};
```

