### PR TITLE
`ParsedRequest` から`HttpResponse`オブジェクトを組み立てるクラスの実装

### DIFF
--- a/srcs/Server/HttpProcessor.cpp
+++ b/srcs/Server/HttpProcessor.cpp
@@ -27,22 +27,14 @@ void HttpProcessor::ProcessHttpRequest(
 void HttpProcessor::ProcessHttpRequestGet(
     const ParsedRequest &parsed_request,
     std::map<std::string, LocationContext> locations, HttpResponse *result) {
-  Path path;
+  Path path(parsed_request.request_path);
 
   // pathってどうやってつかうの？
-  path.SetFilePath("", parsed_request.request_path);
-  path.SetLocation(locations);
+  path.SetLocation(&locations);
 
-  // for (auto& loc : locations) {
-  //   File file(path.GetFilePath() + loc.second);
-  //   if (file.IsExist() && file.CanRead()) {
-  //     // fullPath
-  //   }
-  // }
+  std::string full_path = path.GetFilePath(&locations);
 
-  // 仮
-  std::string full_path = "./html/sample.html";
-
+  std::cout << full_path << std::endl;
   File file(full_path);
   if (file.IsExist() && file.CanRead()) {
     ReadLocalFile(file, result);

--- a/srcs/Server/HttpProcessor.cpp
+++ b/srcs/Server/HttpProcessor.cpp
@@ -3,8 +3,6 @@
 
 #include <vector>
 
-#include "HttpResponse.hpp"
-
 HttpProcessor::HttpProcessor() {}
 
 HttpProcessor::HttpProcessor(HttpProcessor const &other) { *this = other; }
@@ -20,7 +18,7 @@ HttpProcessor::~HttpProcessor() {}
 
 void HttpProcessor::ProcessHttpRequest(
     const ParsedRequest &parsed_request,
-    std::map<std::string, LocationContext> locations, std::string *result) {
+    std::map<std::string, LocationContext> locations, HttpResponse *result) {
   if (parsed_request.m == kGet) {
     ProcessHttpRequestGet(parsed_request, locations, result);
   }
@@ -28,7 +26,7 @@ void HttpProcessor::ProcessHttpRequest(
 
 void HttpProcessor::ProcessHttpRequestGet(
     const ParsedRequest &parsed_request,
-    std::map<std::string, LocationContext> locations, std::string *result) {
+    std::map<std::string, LocationContext> locations, HttpResponse *result) {
   Path path;
 
   // pathってどうやってつかうの？
@@ -48,21 +46,20 @@ void HttpProcessor::ProcessHttpRequestGet(
   File file(full_path);
   if (file.IsExist() && file.CanRead()) {
     ReadLocalFile(file, result);
+  } else {
+    result->SetStatusCode(404);
   }
 }
 
-void HttpProcessor::ReadLocalFile(const File &file, std::string *result) {
-  HttpResponse http_response;
-
-  http_response.SetStatusCode(200);
-  http_response.SetHeader("Content-Type", "text/html");
+void HttpProcessor::ReadLocalFile(const File &file, HttpResponse *result) {
+  result->SetStatusCode(200);
+  result->SetHeader("Content-Type", "text/html");
   std::vector<std::string> file_contents = file.StoreFileLinesInVec();
   std::string body;
   for (std::vector<std::string>::iterator it = file_contents.begin();
        it != file_contents.end(); ++it) {
     body += *it;
   }
-  http_response.SetBody(body);
-  http_response.SetHeader("Content-Length", http_response.GetBody().size());
-  *result = http_response.GetRawResponse();
+  result->SetBody(body);
+  result->SetHeader("Content-Length", result->GetBody().size());
 }

--- a/srcs/Server/HttpProcessor.cpp
+++ b/srcs/Server/HttpProcessor.cpp
@@ -1,0 +1,68 @@
+
+#include "HttpProcessor.hpp"
+
+#include <vector>
+
+#include "HttpResponse.hpp"
+
+HttpProcessor::HttpProcessor() {}
+
+HttpProcessor::HttpProcessor(HttpProcessor const &other) { *this = other; }
+
+HttpProcessor &HttpProcessor::operator=(HttpProcessor const &other) {
+  if (this != &other) {
+    (void)other;
+  }
+  return *this;
+}
+
+HttpProcessor::~HttpProcessor() {}
+
+void HttpProcessor::ProcessHttpRequest(
+    const ParsedRequest &parsed_request,
+    std::map<std::string, LocationContext> locations, std::string *result) {
+  if (parsed_request.m == kGet) {
+    ProcessHttpRequestGet(parsed_request, locations, result);
+  }
+}
+
+void HttpProcessor::ProcessHttpRequestGet(
+    const ParsedRequest &parsed_request,
+    std::map<std::string, LocationContext> locations, std::string *result) {
+  Path path;
+
+  // pathってどうやってつかうの？
+  path.SetFilePath("", parsed_request.request_path);
+  path.SetLocation(locations);
+
+  // for (auto& loc : locations) {
+  //   File file(path.GetFilePath() + loc.second);
+  //   if (file.IsExist() && file.CanRead()) {
+  //     // fullPath
+  //   }
+  // }
+
+  // 仮
+  std::string full_path = "./html/sample.html";
+
+  File file(full_path);
+  if (file.IsExist() && file.CanRead()) {
+    ReadLocalFile(file, result);
+  }
+}
+
+void HttpProcessor::ReadLocalFile(const File &file, std::string *result) {
+  HttpResponse http_response;
+
+  http_response.SetStatusCode(200);
+  http_response.SetHeader("Content-Type", "text/html");
+  std::vector<std::string> file_contents = file.StoreFileLinesInVec();
+  std::string body;
+  for (std::vector<std::string>::iterator it = file_contents.begin();
+       it != file_contents.end(); ++it) {
+    body += *it;
+  }
+  http_response.SetBody(body);
+  http_response.SetHeader("Content-Length", http_response.GetBody().size());
+  *result = http_response.GetRawResponse();
+}

--- a/srcs/Server/HttpProcessor.hpp
+++ b/srcs/Server/HttpProcessor.hpp
@@ -1,0 +1,31 @@
+#ifndef SRCS_SERVER_HTTPPROCESSOR_HPP_
+#define SRCS_SERVER_HTTPPROCESSOR_HPP_
+
+#include <map>
+#include <string>
+
+#include "File.hpp"
+#include "Path.hpp"
+#include "ReceiveHttpRequest.hpp"
+#include "ServerContext.hpp"
+
+class HttpProcessor {
+ public:
+  HttpProcessor();
+  ~HttpProcessor();
+
+  static void ProcessHttpRequest(
+      const ParsedRequest &parsed_request,
+      std::map<std::string, LocationContext> locations, std::string *result);
+
+ private:
+  HttpProcessor(HttpProcessor const &other);
+  HttpProcessor &operator=(HttpProcessor const &other);
+
+  static void ProcessHttpRequestGet(
+      const ParsedRequest &parsed_request,
+      std::map<std::string, LocationContext> locations, std::string *result);
+  static void ReadLocalFile(const File &file, std::string *result);
+};
+
+#endif  // SRCS_SERVER_HTTPPROCESSOR_HPP_

--- a/srcs/Server/HttpProcessor.hpp
+++ b/srcs/Server/HttpProcessor.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "File.hpp"
+#include "HttpResponse.hpp"
 #include "Path.hpp"
 #include "ReceiveHttpRequest.hpp"
 #include "ServerContext.hpp"
@@ -16,7 +17,7 @@ class HttpProcessor {
 
   static void ProcessHttpRequest(
       const ParsedRequest &parsed_request,
-      std::map<std::string, LocationContext> locations, std::string *result);
+      std::map<std::string, LocationContext> locations, HttpResponse *result);
 
  private:
   HttpProcessor(HttpProcessor const &other);
@@ -24,8 +25,8 @@ class HttpProcessor {
 
   static void ProcessHttpRequestGet(
       const ParsedRequest &parsed_request,
-      std::map<std::string, LocationContext> locations, std::string *result);
-  static void ReadLocalFile(const File &file, std::string *result);
+      std::map<std::string, LocationContext> locations, HttpResponse *result);
+  static void ReadLocalFile(const File &file, HttpResponse *result);
 };
 
 #endif  // SRCS_SERVER_HTTPPROCESSOR_HPP_

--- a/srcs/Server/HttpResponse.cpp
+++ b/srcs/Server/HttpResponse.cpp
@@ -92,18 +92,20 @@ HTTP message: https://httpwg.org/specs/rfc9112.html#message.format
                    CRLF
                    [ message-body ]
 */
-std::vector<std::string> HttpResponse::GetResponse() const {
-  std::vector<std::string> response;
+std::string HttpResponse::GetRawResponse() const {
+  std::string response;
 
-  response.push_back(this->GetStatusLine());
+  response += this->GetStatusLine();
 
   std::vector<std::string> headers = this->GetResponseHeaders();
-  response.insert(response.end(), headers.begin(), headers.end());
-
-  response.push_back(kCRLF);
+  for (std::vector<std::string>::iterator it = headers.begin();
+       it != headers.end(); it++) {
+    response += *it;
+  }
+  response += kCRLF;
 
   if (this->body_.size() > 0) {
-    response.push_back(GetBody());
+    response += GetBody();
   }
 
   return response;

--- a/srcs/Server/HttpResponse.hpp
+++ b/srcs/Server/HttpResponse.hpp
@@ -22,7 +22,7 @@ class HttpResponse {
   int GetStatusCode() const;
   std::string const &GetBody() const;
   std::string GetStatusLine() const;
-  std::vector<std::string> GetResponse() const;
+  std::string GetRawResponse() const;
   void SetHttpResponse200();
   std::vector<std::string> GetResponseHeaders() const;
 

--- a/srcs/Server/Path.cpp
+++ b/srcs/Server/Path.cpp
@@ -36,7 +36,6 @@ Path &Path::operator=(Path const &other) {
 
 Path::~Path() {}
 
-
 void Path::SetLocation(Locationmap *locs) {
   std::vector<std::string> location_vector = LocationSort(*locs);
   std::string path;
@@ -73,7 +72,7 @@ void Path::SetLocation(Locationmap *locs) {
   }
 }
 
-void Path::SetFilePath(const std::string &name, const std::string &path) {
+void Path::SetFilePath(const std::string name, const std::string path) {
   file_name_ = name;
   file_path_ = path;
 }

--- a/srcs/Server/Path.cpp
+++ b/srcs/Server/Path.cpp
@@ -21,7 +21,7 @@ Path &Path::operator=(Path const &other) {
 
 Path::~Path() {}
 
-std::string Path::SedLocation(const Locmap &locs) {
+std::string Path::SetLocation(const Locmap &locs) {
   for (Locmap::const_iterator itr = locs.begin(); itr != locs.end(); itr++) {
     std::string path = itr->first;
     std::string root = itr->second.root;
@@ -34,7 +34,7 @@ std::string Path::SedLocation(const Locmap &locs) {
   return "";
 }
 
-void Path::SetFilePath(std::string name, std::string path) {
+void Path::SetFilePath(const std::string &name, const std::string &path) {
   file_name_ = name;
   file_path_ = path;
 }

--- a/srcs/Server/Path.hpp
+++ b/srcs/Server/Path.hpp
@@ -15,8 +15,8 @@ class Path {
   Path(Path const &other);
   Path &operator=(Path const &other);
   ~Path();
-  std::string SedLocation(const Locmap &locs);
-  void SetFilePath(std::string name, std::string path);
+  std::string SetLocation(const Locmap &locs);
+  void SetFilePath(const std::string &name, const std::string &path);
 
  private:
   std::string file_name_;

--- a/srcs/Server/Path.hpp
+++ b/srcs/Server/Path.hpp
@@ -21,7 +21,6 @@ class Path {
   void SetFilePath(std::string name, std::string path);
   std::string GetFilePath(Locationmap *location);
 
-
  private:
   std::string file_name_;
   std::string file_path_;

--- a/srcs/Server/Server.hpp
+++ b/srcs/Server/Server.hpp
@@ -28,7 +28,7 @@ class Server {
   std::map<int, Event *> events_;
   Epoll epoll_;
   ReceiveHttpRequest receive_request_;
-  std::map<int, std::vector<std::string> > response_;
+  std::map<int, std::string> response_;
   void ExecEvents(epoll_event *ev);
   void AcceptNewConnections(epoll_event *ev);
   void ConnectingEvent(epoll_event *ev);

--- a/tests/unit_test/FileTest.cc
+++ b/tests/unit_test/FileTest.cc
@@ -10,53 +10,53 @@
 // 	File f("./text/read_perm.txt");
 // 	EXPECT_EQ(f.READ_PERMISSION,f.Status());
 // }
-TEST(fileStatus,isdir){
-	File f("./text/is_dir");
-	EXPECT_EQ(true,f.IsDir());
+TEST(fileStatus, isdir) {
+  File f("./text/is_dir");
+  EXPECT_EQ(true, f.IsDir());
 }
-TEST(fileStatus,notFound){
-	File f("./text/a");
-	EXPECT_EQ(false,f.IsExist());
+TEST(fileStatus, notFound) {
+  File f("./text/a");
+  EXPECT_EQ(false, f.IsExist());
 }
-TEST(fileStatus,ok){
-	File f("./text/ok.txt");
-	EXPECT_EQ(true,f.CanRead());
+TEST(fileStatus, ok) {
+  File f("./text/ok.txt");
+  EXPECT_EQ(true, f.CanRead());
 }
-TEST(fileRead,normal){
-	File f("./text/normal.txt");
-	std::string a = "aaa\nbbb\nccc";
-	EXPECT_EQ(a,f.ReadFileLines());
+TEST(fileRead, normal) {
+  File f("./text/normal.txt");
+  std::string a = "aaa\nbbb\nccc";
+  EXPECT_EQ(a, f.ReadFileLines());
 }
-TEST(fileRead,empty){
-	File f("./text/empty.txt");
-	std::string str;
-	EXPECT_EQ(str,f.ReadFileLines());
+TEST(fileRead, empty) {
+  File f("./text/empty.txt");
+  std::string str;
+  EXPECT_EQ(str, f.ReadFileLines());
 }
-TEST(fileRead,newline){
-	File f("./text/newline.txt");
-	std::string str = "\n";
-	EXPECT_EQ(str,f.ReadFileLines());
+TEST(fileRead, newline) {
+  File f("./text/newline.txt");
+  std::string str = "\n";
+  EXPECT_EQ(str, f.ReadFileLines());
 }
-TEST(fileReadVec,normal){
-	File f("./text/normal.txt");
-	std::string a = "aaa";
-	std::string b = "bbb";
-	std::string c = "ccc";
-	std::vector<std::string> v;
-	v.push_back(a);
-	v.push_back(b);
-	v.push_back(c);
-	EXPECT_EQ(v,f.StoreFileLinesInVec());
+TEST(fileReadVec, normal) {
+  File f("./text/normal.txt");
+  std::string a = "aaa";
+  std::string b = "bbb";
+  std::string c = "ccc";
+  std::vector<std::string> v;
+  v.push_back(a);
+  v.push_back(b);
+  v.push_back(c);
+  EXPECT_EQ(v, f.StoreFileLinesInVec());
 }
-TEST(fileReadVec,empty){
-	File f("./text/empty.txt");
-	std::vector<std::string> v;
-	EXPECT_EQ(v,f.StoreFileLinesInVec());
+TEST(fileReadVec, empty) {
+  File f("./text/empty.txt");
+  std::vector<std::string> v;
+  EXPECT_EQ(v, f.StoreFileLinesInVec());
 }
-TEST(fileReadVec,newline){
-	File f("./text/newline.txt");
-	std::string str;
-	std::vector<std::string> v;
-	v.push_back(str);
-	EXPECT_EQ(v,f.StoreFileLinesInVec());
+TEST(fileReadVec, newline) {
+  File f("./text/newline.txt");
+  std::string str;
+  std::vector<std::string> v;
+  v.push_back(str);
+  EXPECT_EQ(v, f.StoreFileLinesInVec());
 }

--- a/tests/unit_test/HttpProcessorTest.cc
+++ b/tests/unit_test/HttpProcessorTest.cc
@@ -11,7 +11,7 @@ TEST(HttpProcessor, ProcessHttpRequest) {
 
   location_contexts["/"] = location_context;
 
-  std::string result;
+  HttpResponse result;
 
   {
     ParsedRequest parsed_request;
@@ -24,11 +24,10 @@ TEST(HttpProcessor, ProcessHttpRequest) {
                                       &result);
   }
 
-  std::string expected;
+  HttpResponse expected;
   {
-    HttpResponse http_response;
-    http_response.SetStatusCode(200);
-    http_response.SetHeader("Content-Type", "text/html");
+    expected.SetStatusCode(200);
+    expected.SetHeader("Content-Type", "text/html");
     File file("./html/sample.html");
     std::vector<std::string> file_contents = file.StoreFileLinesInVec();
 
@@ -36,10 +35,9 @@ TEST(HttpProcessor, ProcessHttpRequest) {
     for (size_t i = 0; i < file_contents.size(); ++i) {
       body += file_contents[i];
     }
-    http_response.SetBody(body);
-    http_response.SetHeader("Content-Length", std::to_string(body.size()));
-    expected = http_response.GetRawResponse();
+    expected.SetBody(body);
+    expected.SetHeader("Content-Length", std::to_string(body.size()));
   }
 
-  EXPECT_EQ(result, expected);
+  EXPECT_EQ(result.GetRawResponse(), expected.GetRawResponse());
 }

--- a/tests/unit_test/HttpProcessorTest.cc
+++ b/tests/unit_test/HttpProcessorTest.cc
@@ -3,7 +3,7 @@
 #include "HttpProcessor.hpp"
 #include "HttpResponse.hpp"
 
-TEST(HttpProcessor, test) {
+TEST(HttpProcessor, ProcessHttpRequest) {
   std::map<std::string, LocationContext> location_contexts;
 
   LocationContext location_context;
@@ -13,26 +13,33 @@ TEST(HttpProcessor, test) {
 
   std::string result;
 
-  ParsedRequest parsed_request;
+  {
+    ParsedRequest parsed_request;
 
-  parsed_request.m = kGet;
-  parsed_request.request_path = "/";
-  parsed_request.version = "HTTP/1.1";
+    parsed_request.m = kGet;
+    parsed_request.request_path = "/";
+    parsed_request.version = "HTTP/1.1";
 
-  HttpProcessor::ProcessHttpRequest(parsed_request, location_contexts, &result);
-
-  HttpResponse http_response;
-  http_response.SetStatusCode(200);
-  http_response.SetHeader("Content-Type", "text/html");
-  File file("./html/sample.html");
-  std::vector<std::string> file_contents = file.StoreFileLinesInVec();
-
-  std::string body;
-  for (size_t i = 0; i < file_contents.size(); ++i) {
-    body += file_contents[i];
+    HttpProcessor::ProcessHttpRequest(parsed_request, location_contexts,
+                                      &result);
   }
-  http_response.SetBody(body);
-  http_response.SetHeader("Content-Length", std::to_string(body.size()));
 
-  EXPECT_EQ(result, http_response.GetRawResponse());
+  std::string expected;
+  {
+    HttpResponse http_response;
+    http_response.SetStatusCode(200);
+    http_response.SetHeader("Content-Type", "text/html");
+    File file("./html/sample.html");
+    std::vector<std::string> file_contents = file.StoreFileLinesInVec();
+
+    std::string body;
+    for (size_t i = 0; i < file_contents.size(); ++i) {
+      body += file_contents[i];
+    }
+    http_response.SetBody(body);
+    http_response.SetHeader("Content-Length", std::to_string(body.size()));
+    expected = http_response.GetRawResponse();
+  }
+
+  EXPECT_EQ(result, expected);
 }

--- a/tests/unit_test/HttpProcessorTest.cc
+++ b/tests/unit_test/HttpProcessorTest.cc
@@ -7,7 +7,7 @@ TEST(HttpProcessor, ProcessHttpRequest) {
   std::map<std::string, LocationContext> location_contexts;
 
   LocationContext location_context;
-  location_context.root = "./html/sample.html";
+  location_context.root = "./html/";
 
   location_contexts["/"] = location_context;
 
@@ -17,7 +17,7 @@ TEST(HttpProcessor, ProcessHttpRequest) {
     ParsedRequest parsed_request;
 
     parsed_request.m = kGet;
-    parsed_request.request_path = "/";
+    parsed_request.request_path = "/sample.html";
     parsed_request.version = "HTTP/1.1";
 
     HttpProcessor::ProcessHttpRequest(parsed_request, location_contexts,

--- a/tests/unit_test/HttpProcessorTest.cc
+++ b/tests/unit_test/HttpProcessorTest.cc
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include "HttpProcessor.hpp"
+#include "HttpResponse.hpp"
+
+TEST(HttpProcessor, test) {
+  std::map<std::string, LocationContext> location_contexts;
+
+  LocationContext location_context;
+  location_context.root = "./html/sample.html";
+
+  location_contexts["/"] = location_context;
+
+  std::string result;
+
+  ParsedRequest parsed_request;
+
+  parsed_request.m = kGet;
+  parsed_request.request_path = "/";
+  parsed_request.version = "HTTP/1.1";
+
+  HttpProcessor::ProcessHttpRequest(parsed_request, location_contexts, &result);
+
+  HttpResponse http_response;
+  http_response.SetStatusCode(200);
+  http_response.SetHeader("Content-Type", "text/html");
+  File file("./html/sample.html");
+  std::vector<std::string> file_contents = file.StoreFileLinesInVec();
+
+  std::string body;
+  for (size_t i = 0; i < file_contents.size(); ++i) {
+    body += file_contents[i];
+  }
+  http_response.SetBody(body);
+  http_response.SetHeader("Content-Length", std::to_string(body.size()));
+
+  EXPECT_EQ(result, http_response.GetRawResponse());
+}

--- a/tests/unit_test/HttpResponseTest.cc
+++ b/tests/unit_test/HttpResponseTest.cc
@@ -84,35 +84,33 @@ TEST(HttpResponseTest_Default, RequestLine_500) {
   EXPECT_EQ(expected, res.GetStatusLine());
 }
 
-TEST(HttpResponseTest_Default, GetResponse) {
+TEST(HttpResponseTest_Default, GetRawResponse) {
   HttpResponse http_response;
   http_response.SetStatusCode(200);
   http_response.SetBody("Hello World");
   http_response.SetHeader("Content-Length", http_response.GetBody().size());
 
-  std::vector<std::string> expected = {
-      "HTTP/1.1 200 OK\r\n", "Content-Length: 11\r\n", "\r\n", "Hello World"};
+  std::string expected =
+      "HTTP/1.1 200 OK\r\n"
+      "Content-Length: 11\r\n"
+      "\r\n"
+      "Hello World";
 
-  std::vector<std::string> res = http_response.GetResponse();
-  for (int i = 0; i < expected.size(); i++) {
-    EXPECT_EQ(expected[i], res[i]);
-  }
+  std::string res = http_response.GetRawResponse();
+  EXPECT_EQ(expected, res);
 }
 
-TEST(HttpResponseTest_Default, GetResponse_400) {
+TEST(HttpResponseTest_Default, GetRawResponse_400) {
   HttpResponse http_response;
   http_response.SetStatusCode(400);
   http_response.SetBody("");
   http_response.SetHeader("Content-Length", http_response.GetBody().size());
 
-  std::vector<std::string> expected = {
-      "HTTP/1.1 400 Bad Request\r\n",
-      "Content-Length: 0\r\n",
-      "\r\n",
-  };
+  std::string expected =
+      "HTTP/1.1 400 Bad Request\r\n"
+      "Content-Length: 0\r\n"
+      "\r\n";
 
-  std::vector<std::string> res = http_response.GetResponse();
-  for (int i = 0; i < expected.size(); i++) {
-    EXPECT_EQ(expected[i], res[i]);
-  }
+  std::string res = http_response.GetRawResponse();
+  EXPECT_EQ(expected, res);
 }

--- a/tests/unit_test/Path_test.cc
+++ b/tests/unit_test/Path_test.cc
@@ -13,7 +13,6 @@ TEST(Path, 1) {
       {"/a/", lc},
   };
 
-
   Path p("/a/bbb/abc.html");
   std::string str = p.GetFilePath(&mapList);
   EXPECT_EQ("/usr/local/www/nginx/bbb/abc.html", str);
@@ -122,6 +121,17 @@ TEST(Path, 10) {
   Path p("/kapounet/pouic/");
   std::string str = p.GetFilePath(&mapList);
   EXPECT_EQ("/tmp/www/", str);
+}
+
+TEST(Path, relarive_path) {
+  LocationContext lc;
+  init(&lc, "./html/");
+  Locationmap mapList = {
+      {"/", lc},
+  };
+  Path p("/sample.html");
+  std::string str = p.GetFilePath(&mapList);
+  EXPECT_EQ("./html/sample.html", str);
 }
 
 // /usr/local/www/nginx/aaa/abc.html

--- a/tests/unit_test/Path_test.cc
+++ b/tests/unit_test/Path_test.cc
@@ -18,7 +18,7 @@ TEST(Path, 1) {
 
   Path p;
   p.SetFilePath("", "/a/bbb/abc.html");
-  std::string str = p.SedLocation(mapList);
+  std::string str = p.SetLocation(mapList);
   EXPECT_EQ("/usr/local/www/nginx/bbb/abc.html", str);
 }
 
@@ -34,7 +34,7 @@ TEST(Path, 2) {
 
   Path p;
   p.SetFilePath("", "/a/bbb/abc.html");
-  std::string str = p.SedLocation(mapList);
+  std::string str = p.SetLocation(mapList);
   EXPECT_EQ("/usr/local/www/nginx/abc.html", str);
 }
 

--- a/tests/unit_test/html/sample.html
+++ b/tests/unit_test/html/sample.html
@@ -1,0 +1,1 @@
+<a> Hello world! </a>


### PR DESCRIPTION
# 関連issue

- Closes #41 

# 概要

`ParsedRequest` は  HTTP Request を表現した構造体である
`HttpResponse` は HTTP Response を表現したクラスである

`HttpProcessor::ProcessHttpRequest()` メソッドは、`ParsedRequest` から `HttpResponse` を作成するメソッドである
このメソッドは以下のように動作する

1. LocationContext を元にファイルの探索を行う
2. 見つかったファイルを read する
3. `HttpResponse` オブジェクトを作成する

# 備考

- `HttpResponse::GetRawResponse()` の返り値の方を `std::vector<std::string>` から `std::string` に変更している
