### PR TITLE
clang-tidy 11.0.1だとreadability-identifier-naming.MacroDefinitionIgnoredRegexp に対応していないため削除

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -111,10 +111,6 @@ CheckOptions:
     value: k
   - key: readability-identifier-naming.StaticVariableCase
     value: lower_case
-  - key: readability-identifier-naming.MacroDefinitionCase
-    value: UPPER_CASE
-  - key: readability-identifier-naming.MacroDefinitionIgnoredRegexp
-    value: "^[A-Z]+(_[A-Z]+)*_$"
   - key: readability-identifier-naming.MemberCase
     value: lower_case
   - key: readability-identifier-naming.PrivateMemberSuffix


### PR DESCRIPTION
表題の通り

GitHub Actions上ではdockerでlinterを動かしている
linterの一つとしてclang-tidyを採用している
debian:stable-slim では、clang-tidyのversionは 11.0.1 である
しかしこれはreadability-identifier-naming.MacroDefinitionIgnoredRegexpに対応していない
したがって、この設定を削除する

11.0.1: https://releases.llvm.org/11.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-identifier-naming.html#cmdoption-arg-macrodefinitionsuffix
12.0.0: https://releases.llvm.org/12.0.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability-identifier-naming.html#cmdoption-arg-MacroDefinitionIgnoredRegexp