### PR TITLE
最長一致しているLocationContextを返すクラスの実装

### DIFF
--- a/srcs/Server/HttpProcessor.cpp
+++ b/srcs/Server/HttpProcessor.cpp
@@ -29,7 +29,6 @@ void HttpProcessor::ProcessHttpRequestGet(
     std::map<std::string, LocationContext> locations, HttpResponse *result) {
   Path path(parsed_request.request_path);
 
-  // pathってどうやってつかうの？
   path.SetLocation(&locations);
 
   std::string full_path = path.GetFilePath(&locations);

--- a/srcs/Server/HttpProcessor.cpp
+++ b/srcs/Server/HttpProcessor.cpp
@@ -27,13 +27,14 @@ void HttpProcessor::ProcessHttpRequest(
 void HttpProcessor::ProcessHttpRequestGet(
     const ParsedRequest &parsed_request,
     std::map<std::string, LocationContext> locations, HttpResponse *result) {
-  Path path(parsed_request.request_path);
+  LocationPair selected_location_context =
+      Path::FindBestLocation(locations, parsed_request.request_path);
 
-  path.SetLocation(&locations);
-
-  std::string full_path = path.GetFilePath(&locations);
+  std::string full_path = Path::GetAliasPath(selected_location_context,
+                                             parsed_request.request_path);
 
   std::cout << full_path << std::endl;
+  selected_location_context.second.root += parsed_request.request_path;
   File file(full_path);
   if (file.IsExist() && file.CanRead()) {
     ReadLocalFile(file, result);

--- a/srcs/Server/Path.cpp
+++ b/srcs/Server/Path.cpp
@@ -1,29 +1,6 @@
 #include "Path.hpp"
 
-bool static Compare(const std::string &left, const std::string &right) {
-  return left.length() > right.length();
-}
-
-std::vector<std::string> static LocationSort(const Locationmap &locs) {
-  std::vector<std::string> v;
-
-  for (Locationmap::const_iterator itr = locs.begin(); itr != locs.end();
-       itr++) {
-    v.push_back(itr->first);
-  }
-  std::sort(v.begin(), v.end(), Compare);
-  return v;
-}
-
 Path::Path() {}
-
-Path::Path(const std::string &path) {
-  std::size_t last_slash = path.find_last_of('/');
-  if (last_slash != std::string::npos) {
-    file_path_ = path.substr(0, last_slash + 1);
-    file_name_ = path.substr(last_slash + 1);
-  }
-}
 
 Path::Path(Path const &other) { *this = other; }
 
@@ -36,48 +13,60 @@ Path &Path::operator=(Path const &other) {
 
 Path::~Path() {}
 
-void Path::SetLocation(Locationmap *locs) {
-  std::vector<std::string> location_vector = LocationSort(*locs);
-  std::string path;
-  std::string root;
-  std::string cat;
-  for (std::vector<std::string>::const_iterator itr = location_vector.begin();
-       itr != location_vector.end(); itr++) {
-    path = *itr;
-    root = (*locs)[path].root;
+LocationPair Path::FindBestLocation(const Locationmap &locations,
+                                    const std::string &request_uri) {
+  LocationPair selected_location;
+  for (std::map<std::string, LocationContext>::const_iterator itr =
+           locations.begin();
+       itr != locations.end(); itr++) {
+    std::string location_uri = itr->first;
+    std::string root = itr->second.root;
 
-    std::string::reverse_iterator it = path.rbegin();
-    if (*it != '/') {
-      path += '/';
+    // location_uri が / で終端していない場合は、完全一致でないとマッチしない
+    if (*location_uri.rbegin() != '/') {
+      if (location_uri == request_uri) {
+        selected_location = *itr;
+      }
+      continue;  // ?
     }
 
-    it = root.rbegin();
-    if (*it != '/') {
-      root += '/';
+    // location_uri が / で終端している場合は、location_uri
+    // で始まる場合はマッチする
+    std::size_t last_slash = request_uri.find_last_of('/');
+    std::string request_directory, request_filename;
+    if (last_slash != std::string::npos) {
+      request_directory = request_uri.substr(0, last_slash + 1);
+      request_filename = request_uri.substr(last_slash + 1);
     }
-
-    it = file_path_.rbegin();
-    if (*it != '/') {
-      file_path_ += '/';
-    }
-
-    if (file_path_.size() >= path.size() &&
-        std::equal(path.begin(), path.end(), file_path_.begin())) {
-      path_ = root + file_path_.erase(0, path.size()) + file_name_;
-    } else if ((file_path_ + file_name_ + '/').size() >= path.size() &&
-               std::equal(path.begin(), path.end(),
-                          (file_path_ + file_name_ + '/').begin())) {
-      path_ = root;
+    if (request_directory.size() >= location_uri.size() &&
+        std::equal(location_uri.begin(), location_uri.end(),
+                   request_directory.begin())) {
+      selected_location = *itr;
+      continue;
     }
   }
+  if (selected_location.first.empty()) {
+    throw LocationNotFound();
+  }
+  return selected_location;
 }
 
-void Path::SetFilePath(const std::string name, const std::string path) {
-  file_name_ = name;
-  file_path_ = path;
+std::string Path::GetAliasPath(const LocationPair &location_pair,
+                               const std::string &request_uri) {
+  std::string location_uri = location_pair.first;
+  std::string root = location_pair.second.root;
+
+  std::size_t last_slash = request_uri.find_last_of('/');
+  std::string request_directory, request_filename;
+  if (last_slash != std::string::npos) {
+    request_directory = request_uri.substr(0, last_slash + 1);
+    request_filename = request_uri.substr(last_slash + 1);
+  }
+
+  std::string alias_path = root + request_uri.substr(location_uri.size());
+  return alias_path;
 }
 
-std::string Path::GetFilePath(Locationmap *location) {
-  SetLocation(location);
-  return path_;
+const char *Path::LocationNotFound::what() const throw() {
+  return "Location Context not found";
 }

--- a/srcs/Server/Path.hpp
+++ b/srcs/Server/Path.hpp
@@ -4,10 +4,12 @@
 #include <algorithm>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "LocationContext.hpp"
 
+typedef std::pair<std::string, LocationContext> LocationPair;
 typedef std::map<std::string, LocationContext> Locationmap;
 
 class Path {
@@ -17,14 +19,15 @@ class Path {
   Path(Path const &other);
   Path &operator=(Path const &other);
   ~Path();
-  void SetLocation(Locationmap *locs);
-  void SetFilePath(std::string name, std::string path);
-  std::string GetFilePath(Locationmap *location);
+  static LocationPair FindBestLocation(const Locationmap &locations,
+                                       const std::string &request_uri);
 
- private:
-  std::string file_name_;
-  std::string file_path_;
-  std::string path_;
+  static std::string GetAliasPath(const LocationPair &location_pair,
+                                  const std::string &request_uri);
+  class LocationNotFound : public std::exception {
+   public:
+    const char *what() const throw();
+  };
 };
 
 #endif  // SRCS_SERVER_PATH_HPP_

--- a/srcs/Server/Server.cpp
+++ b/srcs/Server/Server.cpp
@@ -62,14 +62,14 @@ void Server::AcceptNewConnections(epoll_event *ev) {
 void Server::ReceiveRequest(epoll_event *epo_ev) {
   Connecting *conn = dynamic_cast<Connecting *>(events_[epo_ev->data.fd]);
   conn->ReadRequest();
-  // if (conn->GetEventStatus() == kWrite) {
-  //   epoll_.Mod(epo_ev, EPOLLOUT);
-  // }
+  if (conn->GetEventStatus() == kWrite) {
+    epoll_.Mod(epo_ev, EPOLLOUT);
+  }
   // if (conn->GetEventStatus() == kCgi) {
-  conn->GetEventStatus();
-  GenerateCgi(epo_ev);
-  epoll_.Mod(epo_ev, 0);
-  //}
+  //   conn->GetEventStatus();
+  //   GenerateCgi(epo_ev);
+  //   epoll_.Mod(epo_ev, 0);
+  // }
 }
 void Server::AddEventToMonitored(Event *sock, uint32_t event_flag) {
   events_.insert(std::make_pair(sock->GetFd(), sock));

--- a/tests/unit_test/Path_test.cc
+++ b/tests/unit_test/Path_test.cc
@@ -4,134 +4,258 @@
 
 #include "LocationContext.hpp"
 
-void init(LocationContext *lc, std::string str) { lc->root = str; }
-
 TEST(Path, 1) {
   LocationContext lc;
-  init(&lc, "/usr/local/www/nginx");
+  lc.root = "/usr/local/www/nginx/";
   Locationmap mapList = {
       {"/a/", lc},
   };
-
-  Path p("/a/bbb/abc.html");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("/usr/local/www/nginx/bbb/abc.html", str);
+  std::string request = "/a/bbb/abc.html";
+  LocationPair pair = Path::FindBestLocation(mapList, request);
+  std::string path = Path::GetAliasPath(pair, request);
+  std::string expected = "/usr/local/www/nginx/bbb/abc.html";
+  EXPECT_EQ(expected, path);
 }
 
 TEST(Path, 2) {
   LocationContext lc;
-  init(&lc, "/usr/local/www/nginx");
+  lc.root = "/usr/local/www/nginx/";
   Locationmap mapList = {
       {"/a/bbb/", lc},
   };
-
-  Path p("/a/bbb/abc.html");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("/usr/local/www/nginx/abc.html", str);
+  std::string request = "/a/bbb/abc.html";
+  LocationPair pair = Path::FindBestLocation(mapList, request);
+  std::string path = Path::GetAliasPath(pair, request);
+  std::string expected = "/usr/local/www/nginx/abc.html";
+  EXPECT_EQ(expected, path);
 }
 
 TEST(Path, 3) {
   LocationContext lc;
-  init(&lc, "/usr/local/www/nginx");
+  lc.root = "/usr/local/www/nginx/";
   Locationmap mapList = {
       {"/a/bbb", lc},
   };
-
-  Path p("/a/bbb/abc.html");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("/usr/local/www/nginx/abc.html", str);
+  std::string request = "/a/bbb/abc.html";
+  EXPECT_THROW(Path::FindBestLocation(mapList, request),
+               Path::LocationNotFound);
 }
 
 TEST(Path, 4) {
   LocationContext lc;
-  init(&lc, "/tmp/www/");
+  lc.root = "/tmp/www/";
   Locationmap mapList = {
       {"/kapounet", lc},
   };
-
-  Path p("/kapounet/pouic/toto/pounet.html");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("/tmp/www/pouic/toto/pounet.html", str);
+  std::string request = "/kapounet/pouic/toto/pounet.html";
+  EXPECT_THROW(Path::FindBestLocation(mapList, request),
+               Path::LocationNotFound);
 }
 
 TEST(Path, 5) {
   LocationContext lc;
-  init(&lc, "/tmp/www/");
+  lc.root = "/tmp/www/";
   Locationmap mapList = {
       {"/kapounet/", lc},
   };
-
-  Path p("/kapounet/pouic/toto/pounet.html");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("/tmp/www/pouic/toto/pounet.html", str);
+  std::string request = "/kapounet/pouic/toto/pounet.html";
+  LocationPair pair = Path::FindBestLocation(mapList, request);
+  std::string path = Path::GetAliasPath(pair, request);
+  std::string expected = "/tmp/www/pouic/toto/pounet.html";
+  EXPECT_EQ(expected, path);
 }
 
 TEST(Path, 6) {
   LocationContext lc;
-  init(&lc, "/tmp/www");
+  lc.root = "/tmp/www/";
   Locationmap mapList = {
-      {"/kapounet/", lc},
+      {"/kapounet", lc},
   };
-
-  Path p("/kapounet/pouic/toto/pounet.html");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("/tmp/www/pouic/toto/pounet.html", str);
+  std::string request = "/kapounet/pouic/toto/pounet.html";
+  EXPECT_THROW(Path::FindBestLocation(mapList, request),
+               Path::LocationNotFound);
 }
 
 TEST(Path, 7) {
   LocationContext lc;
-  init(&lc, "/tmp/www");
+  lc.root = "/tmp/www/";
   Locationmap mapList = {
       {"/kapounet", lc},
       {"/kapounet/pouic", lc},
   };
-  Path p("/kapounet/pouic/toto/pounet.html");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("/tmp/www/toto/pounet.html", str);
+  std::string request = "/kapounet/pouic/toto/pounet.html";
+  EXPECT_THROW(Path::FindBestLocation(mapList, request),
+               Path::LocationNotFound);
 }
 
 TEST(Path, 8) {
   LocationContext lc;
-  init(&lc, "/tmp/www");
+  lc.root = "/tmp/www/";
   Locationmap mapList = {
       {"/kapounet/pouic", lc},
   };
-  Path p("/kapounet/pouic");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("/tmp/www/", str);
+  std::string request = "/kapounet/pouic";
+  LocationPair pair = Path::FindBestLocation(mapList, request);
+  std::string path = Path::GetAliasPath(pair, request);
+  std::string expected = "/tmp/www/";
+  EXPECT_EQ(expected, path);
 }
 
-TEST(Path, 9) {
-  LocationContext lc;
-  init(&lc, "/tmp/www");
+// add
+
+TEST(Path, saample) {
+  LocationContext lc1, lc2;
+  lc1.root = "/tmp/www";
+  lc2.root = "/tmp/www2";  // match
   Locationmap mapList = {
-      {"/kapounet/pouic/", lc},
+      {"/kapounet", lc1},
+      {"/kapounet/pouic", lc2},
   };
-  Path p("/kapounet/pouic/");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("/tmp/www/", str);
+
+  std::string request_uri = "/kapounet/pouic";
+  LocationPair lp = Path::FindBestLocation(mapList, request_uri);
+  EXPECT_EQ(lc2.root, lp.second.root);
 }
 
-TEST(Path, 10) {
-  LocationContext lc;
-  init(&lc, "/tmp/www");
+TEST(Path, exact_match) {
+  LocationContext lc1, lc2;
+  lc1.root = "/ok";  // match
+  lc2.root = "/ng";
   Locationmap mapList = {
-      {"/kapounet/pouic/", lc},
+      {"/images", lc1},  // ok
+      {"/", lc2},        // ng
   };
-  Path p("/kapounet/pouic/");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("/tmp/www/", str);
+
+  std::string request_uri = "/images";
+  LocationPair lp = Path::FindBestLocation(mapList, request_uri);
+  EXPECT_EQ(lc1.root, lp.second.root);
 }
 
-TEST(Path, relarive_path) {
-  LocationContext lc;
-  init(&lc, "./html/");
+TEST(Path, exact_match2) {
+  LocationContext lc1, lc2;
+  lc1.root = "/ng";
+  lc2.root = "/ok";  // match
   Locationmap mapList = {
-      {"/", lc},
+      {"/images", lc1},  // ng
+      {"/", lc2},        // ok
   };
-  Path p("/sample.html");
-  std::string str = p.GetFilePath(&mapList);
-  EXPECT_EQ("./html/sample.html", str);
+
+  std::string request_uri = "/images/index.html";
+  LocationPair lp = Path::FindBestLocation(mapList, request_uri);
+  EXPECT_EQ(lc2.root, lp.second.root);
+}
+
+TEST(Path, exact_match3) {
+  LocationContext lc1, lc2;
+  lc1.root = "/ok";  // match
+  lc2.root = "/ng";
+  Locationmap mapList = {
+      {"/images", lc1},  // ng
+      {"/", lc2},        // ok
+  };
+
+  std::string request_uri = "/images/";
+  LocationPair lp = Path::FindBestLocation(mapList, request_uri);
+  EXPECT_EQ(lc2.root, lp.second.root);
+}
+
+TEST(Path, exact_match4) {
+  LocationContext lc1, lc2, lc3;
+  lc1.root = "/ng";
+  lc2.root = "/ng2";
+  lc3.root = "/ok";  // match
+  Locationmap mapList = {
+      {"/images", lc1},   // ng
+      {"/", lc2},         // ng
+      {"/images/", lc3},  // ok
+  };
+
+  std::string request_uri = "/images/";
+  LocationPair lp = Path::FindBestLocation(mapList, request_uri);
+  EXPECT_EQ(lc3.root, lp.second.root);
+}
+
+TEST(PATH, exact_match5) {
+  LocationContext lc1, lc2, lc3;
+  lc1.root = "/ng";
+  lc2.root = "/ng2";
+  lc3.root = "/ok";  // match
+  Locationmap mapList = {
+      {"/images", lc1},   // ng
+      {"/", lc2},         // ng
+      {"/images/", lc3},  // ok
+  };
+
+  std::string request_uri = "/images/";
+  LocationPair lp = Path::FindBestLocation(mapList, request_uri);
+  EXPECT_EQ(lc3.root, lp.second.root);
+}
+
+TEST(PATH, longest_match1) {
+  LocationContext lc1, lc2, lc3;
+  Locationmap mapList = {
+      {"/", lc1},          // ng
+      {"/images/", lc2},   // ok
+      {"/images/a", lc3},  // ng
+  };
+
+  std::string request_uri = "/images/abcdef";
+  LocationPair lp = Path::FindBestLocation(mapList, request_uri);
+  EXPECT_EQ(lc2.root, lp.second.root);
+}
+
+TEST(PATH, longest_match2) {
+  LocationContext lc1, lc2, lc3;
+  Locationmap mapList = {
+      {"/", lc1},                // ng
+      {"/images/", lc2},         // ok
+      {"/images/abcdefg", lc3},  // ng
+  };
+
+  std::string request_uri = "/images/abcdef";
+  LocationPair lp = Path::FindBestLocation(mapList, request_uri);
+  EXPECT_EQ(lc2.root, lp.second.root);
+}
+
+TEST(PATH, longest_match3) {
+  LocationContext lc1, lc2, lc3, lc4;
+  Locationmap mapList = {
+      {"/", lc1},             // ng
+      {"/images/", lc2},      // ng
+      {"/images/jpg/", lc3},  // ng
+      {"/images/png/", lc4},  // ok
+  };
+
+  std::string request_uri = "/images/png/abcdef";
+  LocationPair lp = Path::FindBestLocation(mapList, request_uri);
+  EXPECT_EQ(lc4.root, lp.second.root);
+}
+
+TEST(PATH, alias_path_append) {
+  LocationContext lc;
+  lc.root = "/tmp/www/";
+  LocationPair lp = {"/", lc};
+  std::string alias_path = Path::GetAliasPath(lp, "/index.html");
+  std::string expected = "/tmp/www/index.html";
+  EXPECT_EQ(alias_path, expected);
+}
+
+TEST(PATH, alias_path_last_not_slashed) {
+  LocationContext lc;
+  lc.root = "/tmp/www";
+  LocationPair lp = {"/", lc};
+  std::string alias_path = Path::GetAliasPath(lp, "/index.html");
+  std::string expected = "/tmp/wwwindex.html";
+  EXPECT_EQ(alias_path, expected);
+}
+
+TEST(PATH, alias_path_wrap) {
+  LocationContext lc;
+  lc.root = "/tmp/www/";
+  LocationPair lp = {"/hoge/fuga/", lc};
+  std::string alias_path = Path::GetAliasPath(lp, "/hoge/fuga/piyo/index.html");
+  std::string expected = "/tmp/www/piyo/index.html";
+  EXPECT_EQ(alias_path, expected);
 }
 
 // /usr/local/www/nginx/aaa/abc.html


### PR DESCRIPTION
# 関連するチケット

closes #78

## 背景
- `auto_index` に対応するために、LocationContextが必要となる
- `std::string Path::GetFilePath()` は2つの機能を同時に行っているため、matchするLocationContextを取り出せない
  - 最長一致したLocationContextを探す
  - LocationContextのrootとrequest_uri からPathを生成する
- 上記の機能を２つの関数に分離する

## 概要

- 以下の関数を実装した
  - `static LocationPair FindBestLocation(const Locationmap &locations, const std::string &request_uri);`
    - matchするLocationContextを探す
    - 参考: https://www.digitalocean.com/community/tutorials/nginx-location-directive
  - `static std::string GetAliasPath(const LocationPair &location_pair, const std::string &request_uri);`
    - LocationContextのrootとrequest_uriからPathを生成する