### PR TITLE
hostヘッダーに合致するサーバーコンテキストを選択する関数を追加

### DIFF
--- a/srcs/Server/ReceiveHttpRequest.cpp
+++ b/srcs/Server/ReceiveHttpRequest.cpp
@@ -218,7 +218,7 @@ ReadStat ReceiveHttpRequest::ReadHttpRequest(const int &fd, ParsedRequest *pr,
       fd_data_.request_header = TrimByPos(&fd_data_.buf, pos, 4);
       fd_data_.pr.request_header = ParseRequestHeader(fd_data_.request_header);
       if (IsValidHeader(&fd_data_)) {
-        sc_ = &SelectServerContext(sc);
+        sc_ = &SelectServerContext(&sc);
         fd_data_.s = kWaitBody;
       } else {
         fd_data_.s = kErrorHeader;
@@ -247,21 +247,21 @@ ParsedRequest ReceiveHttpRequest::GetParsedRequest() const {
 }
 
 ServerContext &ReceiveHttpRequest::SelectServerContext(
-    std::vector<ServerContext> &contexts) const {
+    std::vector<ServerContext> *contexts) const {
   std::string hostname;
-  if (contexts.size() > 1) {
+  if (contexts->size() > 1) {
     try {
       hostname = GetValueByKey("host");
     } catch (...) {
-      return *contexts.begin();
+      return *contexts->begin();
     }
 
-    for (std::vector<ServerContext>::iterator it = contexts.begin();
-         it != contexts.end(); it++) {
+    for (std::vector<ServerContext>::iterator it = contexts->begin();
+         it != contexts->end(); it++) {
       if (it->server_name == hostname) return *it;
     }
   }
-  return *contexts.begin();
+  return *contexts->begin();
 }
 
 std::string &ReceiveHttpRequest::GetValueByKey(const std::string &key) const {

--- a/srcs/Server/ReceiveHttpRequest.hpp
+++ b/srcs/Server/ReceiveHttpRequest.hpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include "ServerContext.hpp"
+
 #define NL "\r\n"
 #define NLNL "\r\n\r\n"
 #define BUFFER_SIZE 8192
@@ -62,16 +64,31 @@ struct HttpRequestData {
 class ReceiveHttpRequest {
  private:
   HttpRequestData fd_data_;
+  ServerContext *sc_;
+
+  class SearchValueByKey {
+    std::string Key_;
+
+   public:
+    SearchValueByKey(std::string key) : Key_(key) {}
+    bool operator()(const std::pair<std::string, std::string> pair) const {
+      return Key_ == pair.first;
+    }
+  };
 
  public:
   ReceiveHttpRequest();
   ReceiveHttpRequest(ReceiveHttpRequest const &other);
   ReceiveHttpRequest &operator=(ReceiveHttpRequest const &other);
   ~ReceiveHttpRequest();
-  ReadStat ReadHttpRequest(const int &fd, ParsedRequest *pr);
+  ReadStat ReadHttpRequest(const int &fd, ParsedRequest *pr,
+                           std::vector<ServerContext> sc);
   void ShowParsedRequest(const int &fd);
   std::string GetBuf();
   ParsedRequest GetParsedRequest() const;
+  ServerContext &SelectServerContext(
+      std::vector<ServerContext> &contexts) const;
+  std::string &GetValueByKey(const std::string &key) const;
 };
 
 #endif  // SRCS_SERVER_RECEIVEHTTPREQUEST_HPP_

--- a/srcs/Server/ReceiveHttpRequest.hpp
+++ b/srcs/Server/ReceiveHttpRequest.hpp
@@ -70,7 +70,7 @@ class ReceiveHttpRequest {
     std::string Key_;
 
    public:
-    SearchValueByKey(std::string key) : Key_(key) {}
+    explicit SearchValueByKey(std::string key) : Key_(key) {}
     bool operator()(const std::pair<std::string, std::string> pair) const {
       return Key_ == pair.first;
     }
@@ -87,7 +87,7 @@ class ReceiveHttpRequest {
   std::string GetBuf();
   ParsedRequest GetParsedRequest() const;
   ServerContext &SelectServerContext(
-      std::vector<ServerContext> &contexts) const;
+      std::vector<ServerContext> *contexts) const;
   std::string &GetValueByKey(const std::string &key) const;
 };
 

--- a/srcs/Server/ReceveRequestFromClient.cpp
+++ b/srcs/Server/ReceveRequestFromClient.cpp
@@ -1,11 +1,15 @@
 #include "ReceveRequestFromClient.hpp"
 
+#include <vector>  // エラー回避のための仮置きのためにおいたstd::vector<ServerContext> scのための仮置き
+
 #include "ResponseToTheClient.hpp"
 ReceveRequestFromClient::ReceveRequestFromClient(Socket *sock)
     : socket_(sock) {}
 ReceveRequestFromClient::~ReceveRequestFromClient() {}
 void ReceveRequestFromClient::Do() {
-  std::vector<ServerContext> sc;  //エラー回避のための仮置き
+  std::vector<ServerContext>
+      sc;  // ↓ReadHttpRequest()のプロトタイプ変更によるエラー回避のための仮置き↓
+
   stat_ = request_.ReadHttpRequest(socket_->sock_fd, &socket_->pr, sc);
   if (IsReadErr(stat_)) {
     socket_->response_code = kKk400BadRequest;

--- a/srcs/Server/ReceveRequestFromClient.cpp
+++ b/srcs/Server/ReceveRequestFromClient.cpp
@@ -5,8 +5,7 @@ ReceveRequestFromClient::ReceveRequestFromClient(Socket *sock)
     : socket_(sock) {}
 ReceveRequestFromClient::~ReceveRequestFromClient() {}
 void ReceveRequestFromClient::Do() {
-  std::vector<ServerContext> sc;
-
+  std::vector<ServerContext> sc;  //エラー回避のための仮置き
   stat_ = request_.ReadHttpRequest(socket_->sock_fd, &socket_->pr, sc);
   if (IsReadErr(stat_)) {
     socket_->response_code = kKk400BadRequest;

--- a/srcs/Server/ReceveRequestFromClient.cpp
+++ b/srcs/Server/ReceveRequestFromClient.cpp
@@ -7,8 +7,7 @@ ReceveRequestFromClient::ReceveRequestFromClient(Socket *sock)
     : socket_(sock) {}
 ReceveRequestFromClient::~ReceveRequestFromClient() {}
 void ReceveRequestFromClient::Do() {
-  std::vector<ServerContext>
-      sc;  // ↓ReadHttpRequest()のプロトタイプ変更によるエラー回避のための仮置き↓
+  std::vector<ServerContext> sc;  // ↓プロトタイプ変更によるエラー回避↓
 
   stat_ = request_.ReadHttpRequest(socket_->sock_fd, &socket_->pr, sc);
   if (IsReadErr(stat_)) {

--- a/srcs/Server/ReceveRequestFromClient.cpp
+++ b/srcs/Server/ReceveRequestFromClient.cpp
@@ -5,7 +5,9 @@ ReceveRequestFromClient::ReceveRequestFromClient(Socket *sock)
     : socket_(sock) {}
 ReceveRequestFromClient::~ReceveRequestFromClient() {}
 void ReceveRequestFromClient::Do() {
-  stat_ = request_.ReadHttpRequest(socket_->sock_fd, &socket_->pr);
+  std::vector<ServerContext> sc;
+
+  stat_ = request_.ReadHttpRequest(socket_->sock_fd, &socket_->pr, sc);
   if (IsReadErr(stat_)) {
     socket_->response_code = kKk400BadRequest;
   } else if (IsReadComplete(stat_)) {

--- a/tests/unit_test/ReceiveHttpRequest_test.cc
+++ b/tests/unit_test/ReceiveHttpRequest_test.cc
@@ -43,9 +43,10 @@ TEST(ReceiveHttpRequest, full) {
   ReceiveHttpRequest rhr;
   ParsedRequest pr;
   ReadStat rs;
+  std::vector<ServerContext> sc;
   int fd = open_pseudo_socket();
   copy_fd(fd, "FullRequest");
-  rs = rhr.ReadHttpRequest(fd, &pr);
+  rs = rhr.ReadHttpRequest(fd, &pr, sc);
 
   EXPECT_EQ(kReadComplete, rs);
   EXPECT_EQ(kPost, pr.m);
@@ -60,15 +61,16 @@ TEST(ReceiveHttpRequest, empty_then_full) {
   ReceiveHttpRequest rhr;
   ParsedRequest pr;
   ReadStat rs;
+  std::vector<ServerContext> sc;
 
   int fd = open_pseudo_socket();
   copy_fd(fd, "EmptyRequest");
-  rs = rhr.ReadHttpRequest(fd, &pr);
+  rs = rhr.ReadHttpRequest(fd, &pr, sc);
 
   EXPECT_EQ(kWaitRequest, rs);
 
   copy_fd(fd, "FullRequest");
-  rs = rhr.ReadHttpRequest(fd, &pr);
+  rs = rhr.ReadHttpRequest(fd, &pr, sc);
 
   EXPECT_EQ(kReadComplete, rs);
   EXPECT_EQ(kReadComplete, rs);
@@ -84,10 +86,12 @@ TEST(ReceiveHttpRequest, only_request_line) {
   ReceiveHttpRequest rhr;
   ParsedRequest pr;
   ReadStat rs;
+  std::vector<ServerContext> sc;
+
   int fd = open_pseudo_socket();
 
   copy_fd(fd, "OnlyRequestLine");
-  rs = rhr.ReadHttpRequest(fd, &pr);
+  rs = rhr.ReadHttpRequest(fd, &pr, sc);
 
   EXPECT_EQ(kWaitHeader, rs);
   EXPECT_EQ(kPost, pr.m);
@@ -100,9 +104,10 @@ TEST(ReceiveHttpRequest, half_then_half) {
   ReceiveHttpRequest rhr;
   ParsedRequest pr;
   ReadStat rs;
+  std::vector<ServerContext> sc;
   int fd = open_pseudo_socket();
   copy_fd(fd, "HalfRequestLine");
-  rs = rhr.ReadHttpRequest(fd, &pr);
+  rs = rhr.ReadHttpRequest(fd, &pr, sc);
   EXPECT_EQ(kWaitRequest, rs);
   EXPECT_EQ(kError, pr.m);
   EXPECT_EQ("", pr.request_path);
@@ -110,7 +115,7 @@ TEST(ReceiveHttpRequest, half_then_half) {
   EXPECT_EQ("POST /search.", rhr.GetBuf());
 
   copy_fd(fd, "HalfRequestLine2");
-  rs = rhr.ReadHttpRequest(fd, &pr);
+  rs = rhr.ReadHttpRequest(fd, &pr, sc);
   EXPECT_EQ(kWaitHeader, rs);
   EXPECT_EQ(kPost, pr.m);
   EXPECT_EQ("/search.html", pr.request_path);
@@ -124,9 +129,10 @@ TEST(ReceiveHttpRequest, invalid_request1) {
   ReceiveHttpRequest rhr;
   ParsedRequest pr;
   ReadStat rs;
+  std::vector<ServerContext> sc;
   int fd = open_pseudo_socket();
   copy_fd(fd, "invalidrequest1");
-  rs = rhr.ReadHttpRequest(fd, &pr);
+  rs = rhr.ReadHttpRequest(fd, &pr, sc);
   close(fd);
 }
 
@@ -134,8 +140,9 @@ TEST(ReceiveHttpRequest, request_then_nobody) {
   ReceiveHttpRequest rhr;
   ParsedRequest pr;
   ReadStat rs;
+  std::vector<ServerContext> sc;
   int fd = open_pseudo_socket();
   copy_fd(fd, "request_then_nobody");
-  rs = rhr.ReadHttpRequest(fd, &pr);
+  rs = rhr.ReadHttpRequest(fd, &pr, sc);
   close(fd);
 }


### PR DESCRIPTION
`ReadHttpRequest()`の第三引数に`std::vector<ServerContext>`を追加し、受け取ったhostフィールドとの比較の上適切なServerContextを選択する機能を追加した。

プロトタイプ変更に伴って`ReceveRequestFromClient.cpp`にエラー回避のために当座の処置として`ReadHttpRequest()`にわたすためだけの空の`std::vector<ServerContext>`を宣言した。

選択された`ServerContext`はReceiveHttpRequestのメンバ変数としてとりあえず設置