### PR TITLE
`autoindex on` のときに一覧を返す

### DIFF
--- a/conf/nginx/default.conf
+++ b/conf/nginx/default.conf
@@ -2,11 +2,12 @@ server {
 	listen 8082;
     location / {
         alias /var/www/;
-        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-        include /etc/nginx/fastcgi_params;
-        fastcgi_pass unix:/var/run/fcgiwrap.socket;
-        fastcgi_index env.cgi;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        # fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+        # include /etc/nginx/fastcgi_params;
+        # fastcgi_pass unix:/var/run/fcgiwrap.socket;
+        # fastcgi_index env.cgi;
+        # fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        autoindex on;
     }
 }
 # server {

--- a/conf/webserv/default.conf
+++ b/conf/webserv/default.conf
@@ -1,8 +1,12 @@
 server {
-  listen 8080;
+  listen 8087;
   location / {
     root ./www/;
     index  index.html;
+  }
+  location /auto/ {
+    root ./www/auto/;
+    autoindex on;
   }
 }
 

--- a/srcs/Server/HttpProcessor.cpp
+++ b/srcs/Server/HttpProcessor.cpp
@@ -3,6 +3,8 @@
 
 #include <vector>
 
+#include "Utils.hpp"
+
 HttpProcessor::HttpProcessor() {}
 
 HttpProcessor::HttpProcessor(HttpProcessor const &other) { *this = other; }
@@ -54,6 +56,7 @@ void HttpProcessor::ProcessHttpRequestGet(
   // fileがdirectoryの場合
   if (file.IsDir()) {
     if (selected_location_context.second.auto_index == "on") {
+      CreateHttpAutoIndexHtml(parsed_request.request_path, full_path, result);
       return;
     }
     ReadIndexFile(full_path, selected_location_context.second, result);
@@ -91,4 +94,36 @@ void HttpProcessor::ReadIndexFile(const std::string &full_path,
     return;
   }
   ReadLocalFile(file, result);
+}
+
+void HttpProcessor::CreateHttpAutoIndexHtml(const std::string &request_path,
+                                            const std::string &full_path,
+                                            HttpResponse *result) {
+  std::string body;
+  body += "<html><head><title>Index of ";
+  body += request_path;
+  body += "</title></head><body bgcolor=\"white\"><h1>Index of ";
+  body += request_path;
+  body += "</h1><hr><pre><a href=\"../\">../</a>\n";
+
+  File file(full_path);
+  std::vector<FileInfo> file_list = file.GetFileListInDir();
+  for (std::vector<FileInfo>::iterator it = file_list.begin();
+       it != file_list.end(); ++it) {
+    FileInfo &file_info = *it;
+    body += "<a href=\"";
+    body += file_info.name;
+    body += "\">";
+    body += file_info.name;
+    body += "\t";
+    body += file_info.timestamp;
+    body += "\t";
+    body += utils::UIntToString(file_info.size);
+    body += "</a>\n";
+    std::cout << file_info.name;
+    std::cout << file_info.timestamp;
+    std::cout << file_info.size << std::endl;
+  }
+  body += "</pre><hr></body></html>";
+  result->SetHttpResponse(200, body);
 }

--- a/srcs/Server/HttpProcessor.hpp
+++ b/srcs/Server/HttpProcessor.hpp
@@ -29,6 +29,9 @@ class HttpProcessor {
   static void ReadLocalFile(const File &file, HttpResponse *result);
   static void ReadIndexFile(const std::string &full_path,
                             const LocationContext &loc, HttpResponse *result);
+  static void CreateHttpAutoIndexHtml(const std::string &request_path,
+                                      const std::string &full_path,
+                                      HttpResponse *result);
 };
 
 #endif  // SRCS_SERVER_HTTPPROCESSOR_HPP_

--- a/srcs/Utils/File.cpp
+++ b/srcs/Utils/File.cpp
@@ -1,5 +1,6 @@
 #include "File.hpp"
 
+#include <dirent.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 
@@ -78,4 +79,40 @@ std::vector<std::string> File::StoreFileLinesInVec() const {
   if (!reading_line.empty()) lines.push_back(reading_line);
   reading_file.close();
   return lines;
+}
+
+std::vector<FileInfo> File::GetFileListInDir() const {
+  std::vector<FileInfo> file_list;
+
+  if (!IsDir()) return file_list;
+  DIR *dir = NULL;
+  struct dirent *ent = NULL;
+  if ((dir = opendir(filename_.c_str())) != NULL) {
+    while ((ent = readdir(dir)) != NULL) {
+      std::string file_name(ent->d_name);
+      std::cout << file_name << std::endl;
+      if (file_name == "." || file_name == "..") {
+        continue;
+      }
+      FileInfo file_info;
+
+      struct stat buf;
+      int exists = stat(filename_.c_str(), &buf);
+      if (exists < 0) {
+        std::cerr << "Could not stat file: " << file_name << std::endl;
+        continue;
+      }
+      char time_buf[50];
+      ctime_r(&buf.st_mtime, time_buf);
+      file_info.timestamp = time_buf;
+      file_info.size = buf.st_size;
+      file_info.name = file_name;
+
+      file_list.push_back(file_info);
+    }
+    closedir(dir);
+  } else {
+    std::cerr << "Could not open directory: " << filename_ << std::endl;
+  }
+  return file_list;
 }

--- a/srcs/Utils/File.hpp
+++ b/srcs/Utils/File.hpp
@@ -4,6 +4,12 @@
 #include <string>
 #include <vector>
 
+struct FileInfo {
+  std::string name;
+  size_t size;
+  std::string timestamp;
+};
+
 class File {
  private:
   std::string filename_;
@@ -26,6 +32,8 @@ class File {
   bool CanExec() const;
 
   void SetFileName(const std::string &name);
+
+  std::vector<FileInfo> GetFileListInDir() const;
 };
 
 #endif  // SRCS_UTILS_FILE_HPP_

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -6,6 +6,9 @@ services:
       dockerfile: ./tests/docker/nginx/Dockerfile
     ports:
       - 8082:8082
+    volumes:
+      - ../../www:/var/www
+      - ../../conf/nginx/default.conf:/etc/nginx/conf.d/default.conf
   webserv:
     build:
       context: ../../

--- a/tests/docker/nginx/Dockerfile
+++ b/tests/docker/nginx/Dockerfile
@@ -3,8 +3,6 @@ FROM debian:buster
 
 RUN apt -y update && apt -y upgrade && apt -y install nginx  vim fcgiwrap
 
-COPY ./www /var/www
-COPY ./conf/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY ./conf/nginx/entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 RUN chmod +x -R /var/www/cgi-bin/*.cgi


### PR DESCRIPTION
# やったこと

- `nginx` コンテナで`www`をマウントするようにした
  - `make nginx_up`
- `HttpProcessor::CreateHttpAutoIndexHtml()` の実装
  - file名の探索は`opendir()`, `readdir()` で行った
  - ファイルの情報は`stat()` から取得した 