### PR TITLE
Redirectの実装

### DIFF
--- a/conf/webserv/default.conf
+++ b/conf/webserv/default.conf
@@ -5,9 +5,10 @@ server {
   location / {
     root /home/wyohe/code/cpp_web_server/www/;
     index  index.html;
-    cgi_extension .cgi;
+    return 302 /auto/;
   }
   location /auto/ {
+    root /home/wyohe/code/cpp_web_server/www/auto/;
     autoindex on;
   }
 }

--- a/srcs/Server/Get.cpp
+++ b/srcs/Server/Get.cpp
@@ -52,7 +52,22 @@ void Get::SetErrorPage(const ResponseCode error_code, Socket *sock) {
   SetResponseCode(response.rescode);
   SetResponseBody(response.body);
 }
+
+void Get::Redirect(ResponseCode rescode, const std::string &path) {
+  AddResponseHeader("Location", path);
+  SetResponseCode(rescode);
+}
+
 void Get::Run(const std::string &path, Socket *sock) {
+  // redirect が存在する場合
+
+  if (sock->location_context.redirect.first != -1) {
+    //
+    Redirect(static_cast<ResponseCode>(sock->location_context.redirect.first),
+             sock->location_context.redirect.second);
+    return;
+  }
+
   // outindex_
   File file(path);
   if (!file.IsExist()) {
@@ -102,7 +117,11 @@ void Get::Run(const std::string &path, Socket *sock) {
 void Get::UpdateSocketData(Socket *sock) {
   sock->response_body = body_;
   sock->response_code = rescode_;
+  sock->headers = headers_;
 }
 
 void Get::SetResponseBody(const std::string &body) { body_ = body; }
 void Get::SetResponseCode(const ResponseCode &rescode) { rescode_ = rescode; }
+void Get::AddResponseHeader(const std::string &key, const std::string &value) {
+  headers_[key] = value;
+}

--- a/srcs/Server/Get.hpp
+++ b/srcs/Server/Get.hpp
@@ -10,6 +10,7 @@ class Get : public HttpMethod {
   ResponseCode rescode_;
   // https://tex2e.github.io/rfc-translater/html/rfc9112.html#6--Message-Body
   std::string body_;
+  HttpResponse::HttpHeaders headers_;
 
  public:
   Get();
@@ -17,9 +18,11 @@ class Get : public HttpMethod {
   void Run(const std::string &path, Socket *sock);
   void UpdateSocketData(Socket *sock);
 
+  void Redirect(ResponseCode rescode, const std::string &path);
   void SetResponseCode(const ResponseCode &rescode);
   void SetResponseBody(const std::string &body);
   void SetErrorPage(const ResponseCode error_code, Socket *sock);
+  void AddResponseHeader(const std::string &key, const std::string &value);
 };
 
 #endif  // SRCS_SERVER_GET_HPP_

--- a/srcs/Server/HttpResponse.cpp
+++ b/srcs/Server/HttpResponse.cpp
@@ -63,6 +63,18 @@ std::string HttpResponse::GetStatusMessage() const {
   switch (this->statusCode_) {
     case 200:
       return "OK";
+    case 201:
+      return "Created";
+
+    case 301:
+      return "Moved Permanently";
+    case 302:
+      return "Found";
+    case 304:
+      return "Not Modified";
+    case 307:
+      return "Temporary Redirect";
+
     case 400:
       return "Bad Request";
     case 403:
@@ -120,9 +132,11 @@ void HttpResponse::SetHttpResponse200() {
 
 HttpResponse::~HttpResponse() {}
 
-void HttpResponse::SetHttpResponse(int status_code, std::string const &body) {
+void HttpResponse::SetHttpResponse(int status_code, std::string const &body,
+                                   const HttpHeaders &headers) {
   this->SetStatusCode(status_code);
   this->SetBody(body);
+  this->headers_.insert(headers.begin(), headers.end());
   this->SetHeader("Content-Type", "text/html");
   this->SetHeader("Connection", "close");
   this->SetHeader("Content-Length", this->GetBody().size());

--- a/srcs/Server/HttpResponse.hpp
+++ b/srcs/Server/HttpResponse.hpp
@@ -26,7 +26,8 @@ class HttpResponse {
   std::string GetRawResponse() const;
   void SetHttpResponse200();
   std::vector<std::string> GetResponseHeaders() const;
-  void SetHttpResponse(int status_code, std::string const &body);
+  void SetHttpResponse(int status_code, std::string const &body,
+                       const HttpHeaders &headers);
 
  private:
   static const char kCRLF[3];

--- a/srcs/Server/ResponseToTheClient.cpp
+++ b/srcs/Server/ResponseToTheClient.cpp
@@ -7,7 +7,8 @@ void ResponseToTheClient::Do() {
   std::cout << "response" << std::endl;
   if (state_ == kWrite) {
     HttpResponse res;
-    res.SetHttpResponse(socket_->response_code, socket_->response_body);
+    res.SetHttpResponse(socket_->response_code, socket_->response_body,
+                        socket_->headers);
     sender_.Init(res.GetRawResponse());
   }
   sender_.Send(socket_->sock_fd);

--- a/srcs/Server/Socket.hpp
+++ b/srcs/Server/Socket.hpp
@@ -59,7 +59,6 @@ struct CgiRes {
 };
 
 class Socket {
- private:
  public:
   static const int kBuffSize = 2048;
   std::vector<ServerContext> vec_context;
@@ -74,6 +73,9 @@ class Socket {
   bool can_write;
   std::string response_body;
   std::vector<CgiRes> cgi_res;
+
+  HttpResponse::HttpHeaders headers;
+
   std::string full_path;
   Socket(int fd, const std::vector<ServerContext>& context);
   ~Socket();

--- a/tests/docker/nginx/Dockerfile
+++ b/tests/docker/nginx/Dockerfile
@@ -5,6 +5,6 @@ RUN apt -y update && apt -y upgrade && apt -y install nginx  vim fcgiwrap
 
 COPY ./conf/nginx/entrypoint.sh /
 RUN chmod +x /entrypoint.sh
-#RUN chmod +x -R /var/www/cgi-bin/*.cgi
+# RUN chmod +x -R /var/www/cgi-bin/*.cgi
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["nginx", "-g" , "daemon off;"]

--- a/tests/unit_test/HttpResponseTest.cc
+++ b/tests/unit_test/HttpResponseTest.cc
@@ -118,13 +118,34 @@ TEST(HttpResponseTest_Default, GetRawResponse_400) {
 TEST(HttpResponseTest_Default, SetHttPresponse_Default) {
   HttpResponse http_response;
 
-  http_response.SetHttpResponse(200, "Hello World");
+  http_response.SetHttpResponse(200, "Hello World",
+                                std::map<std::string, std::string>());
 
   std::string expected =
       "HTTP/1.1 200 OK\r\n"
       "Connection: close\r\n"
       "Content-Length: 11\r\n"
       "Content-Type: text/html\r\n"
+      "\r\n"
+      "Hello World";
+
+  std::string res = http_response.GetRawResponse();
+  EXPECT_EQ(expected, res);
+}
+
+TEST(HttpResponseTest_Default, SetHttPresponse_Redirect) {
+  HttpResponse http_response;
+
+  http_response.SetHttpResponse(302, "Hello World",
+                                std::map<std::string, std::string>(
+                                    {{"Location", "http://localhost:8080"}}));
+
+  std::string expected =
+      "HTTP/1.1 302 Found\r\n"
+      "Connection: close\r\n"
+      "Content-Length: 11\r\n"
+      "Content-Type: text/html\r\n"
+      "Location: http://localhost:8080\r\n"
       "\r\n"
       "Hello World";
 


### PR DESCRIPTION
Closes #84 

redirect を実装した

Socketクラスに HTTP fields を管理するための `headers` 変数を追加した