### PR TITLE
autoindex のページでdirectoryを表示する場合に `/` を出力する

### DIFF
--- a/conf/nginx/default.conf
+++ b/conf/nginx/default.conf
@@ -12,7 +12,8 @@ server {
         autoindex on;
     }
     location /auto/ {
-        alias /var/www/auto/;
+        alias /var/www/;
+        autoindex on;
     }
 }
 # server {

--- a/conf/webserv/default.conf
+++ b/conf/webserv/default.conf
@@ -1,14 +1,14 @@
 server {
   listen 8087;
-  error_page 404 /error404.html;
+  error_page 311 /error404.html;
 
   location / {
-    root /home/wyohe/code/cpp_web_server/www/;
+    root /home/akky/src/github.com/42Student-July/cpp_web_server/www/;
     index  index.html;
-    return 302 /auto/;
+    return 555 /auto/;
   }
   location /auto/ {
-    root /home/wyohe/code/cpp_web_server/www/auto/;
+    root /home/akky/src/github.com/42Student-July/cpp_web_server/www/;
     autoindex on;
   }
 }

--- a/srcs/Server/Get.cpp
+++ b/srcs/Server/Get.cpp
@@ -62,7 +62,6 @@ void Get::Run(const std::string &path, Socket *sock) {
   // redirect が存在する場合
 
   if (sock->location_context.redirect.first != -1) {
-    //
     Redirect(static_cast<ResponseCode>(sock->location_context.redirect.first),
              sock->location_context.redirect.second);
     return;

--- a/srcs/Utils/File.cpp
+++ b/srcs/Utils/File.cpp
@@ -112,7 +112,7 @@ std::vector<FileInfo> File::GetFileListInDir() const {
       FileInfo file_info;
 
       struct stat buf;
-      int exists = stat(filename_.c_str(), &buf);
+      int exists = stat((filename_ + file_name).c_str(), &buf);
       if (exists < 0) {
         std::cerr << "Could not stat file: " << file_name << std::endl;
         continue;
@@ -121,7 +121,13 @@ std::vector<FileInfo> File::GetFileListInDir() const {
       ctime_r(&buf.st_mtime, time_buf);
       file_info.timestamp = time_buf;
       file_info.size = buf.st_size;
-      file_info.name = file_name;
+      if (S_ISREG(buf.st_mode)) {
+        file_info.name = file_name;
+      } else if (S_ISDIR(buf.st_mode)) {
+        file_info.name = file_name + "/";
+      } else {
+        file_info.name = file_name;
+      }
 
       file_list.push_back(file_info);
     }


### PR DESCRIPTION
# 関連するチケット

Closes  #101

# 変更点

表題の通り
direcotory にもかかわらず`/`をつけないと、ブラウザ側のリクエストがおかしくなるため修正した