### PR TITLE
location ディレクティブのuriからパスを探索するアルゴリズムを修正した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ tests/unit_test/text/ReceiveHttpRequest/pseudo_socket.txt
 *.exe
 *.out
 *.app
+
+webserv-tester

--- a/srcs/Server/Path.cpp
+++ b/srcs/Server/Path.cpp
@@ -16,26 +16,24 @@ Path::~Path() {}
 
 LocationPair Path::FindBestLocation(const Locationmap &locations,
                                     const std::string &request_uri) {
-  LocationPair selected_location;
+  LocationPair max_path_length_location;
   for (std::map<std::string, LocationContext>::const_iterator itr =
            locations.begin();
        itr != locations.end(); itr++) {
     std::string location_uri = itr->first;
-    std::string root = itr->second.root;
 
-    std::string request_directory = request_uri.substr(0, request_uri.size());
-    std::string request_filename = request_uri.substr(request_uri.size());
-
-    if (request_directory.size() >= location_uri.size() &&
+    if (request_uri.size() >= location_uri.size() &&
         utils::StartWith(request_uri, location_uri)) {
-      selected_location = *itr;
+      if (max_path_length_location.first.size() < location_uri.size()) {
+        max_path_length_location = *itr;
+      }
       continue;
     }
   }
-  if (selected_location.first.empty()) {
+  if (max_path_length_location.first.empty()) {
     throw LocationNotFound();
   }
-  return selected_location;
+  return max_path_length_location;
 }
 
 std::string Path::GetAliasPath(const LocationPair &location_pair,

--- a/srcs/Server/Path.cpp
+++ b/srcs/Server/Path.cpp
@@ -23,25 +23,11 @@ LocationPair Path::FindBestLocation(const Locationmap &locations,
     std::string location_uri = itr->first;
     std::string root = itr->second.root;
 
-    // location_uri が / で終端していない場合は、完全一致でないとマッチしない
-    if (*location_uri.rbegin() != '/') {
-      if (location_uri == request_uri) {
-        selected_location = *itr;
-      }
-      continue;  // ?
-    }
+    std::string request_directory = request_uri.substr(0, request_uri.size());
+    std::string request_filename = request_uri.substr(request_uri.size());
 
-    // location_uri が / で終端している場合は、location_uri
-    // で始まる場合はマッチする
-    std::size_t last_slash = request_uri.find_last_of('/');
-    std::string request_directory, request_filename;
-    if (last_slash != std::string::npos) {
-      request_directory = request_uri.substr(0, last_slash + 1);
-      request_filename = request_uri.substr(last_slash + 1);
-    }
     if (request_directory.size() >= location_uri.size() &&
-        std::equal(location_uri.begin(), location_uri.end(),
-                   request_directory.begin())) {
+        utils::StartWith(request_uri, location_uri)) {
       selected_location = *itr;
       continue;
     }
@@ -56,13 +42,6 @@ std::string Path::GetAliasPath(const LocationPair &location_pair,
                                const std::string &request_uri) {
   std::string location_uri = location_pair.first;
   std::string root = location_pair.second.root;
-
-  std::size_t last_slash = request_uri.find_last_of('/');
-  std::string request_directory, request_filename;
-  if (last_slash != std::string::npos) {
-    request_directory = request_uri.substr(0, last_slash + 1);
-    request_filename = request_uri.substr(last_slash + 1);
-  }
 
   std::string alias_path = root + request_uri.substr(location_uri.size());
   return alias_path;

--- a/srcs/Utils/Utils.cpp
+++ b/srcs/Utils/Utils.cpp
@@ -101,4 +101,8 @@ std::string ToStr(const Method &m) {
   if (m == kGet) return "GET";
   return "";
 }
+
+bool StartWith(const std::string &str, const std::string &prefix) {
+  return std::equal(prefix.begin(), prefix.end(), str.begin());
+}
 }  // namespace utils

--- a/srcs/Utils/Utils.hpp
+++ b/srcs/Utils/Utils.hpp
@@ -26,6 +26,7 @@ void DelPtr(char **ptr);
 char **MapToCharDoublePtr(const std::map<std::string, std::string> &m);
 char **VecToCharDoublePtr(const std::vector<std::string> &vec);
 std::string ToStr(const Method &m);
+bool StartWith(const std::string &str, const std::string &prefix);
 }  // namespace utils
 
 #endif  // SRCS_UTILS_UTILS_HPP_

--- a/tests/unit_test/Makefile
+++ b/tests/unit_test/Makefile
@@ -8,7 +8,7 @@ TESTSRCS = $(wildcard *.cc)
 TESTOBJS = $(TESTSRCS:%.cc=%.o)
 UNIT_TEST_NAME = unit_test
 CXX	= g++
-CXXFLAGS = -std=c++11
+CXXFLAGS = -std=c++11 -g -fsanitize=address
 NAME = unit_test
 RM = rm -f
 

--- a/tests/unit_test/Makefile
+++ b/tests/unit_test/Makefile
@@ -8,7 +8,7 @@ TESTSRCS = $(wildcard *.cc)
 TESTOBJS = $(TESTSRCS:%.cc=%.o)
 UNIT_TEST_NAME = unit_test
 CXX	= g++
-CXXFLAGS = -std=c++11 -g -fsanitize=address
+CXXFLAGS = -std=c++11 #t a-g -fsanitize=address
 NAME = unit_test
 RM = rm -f
 

--- a/tests/unit_test/Path_test.cc
+++ b/tests/unit_test/Path_test.cc
@@ -37,8 +37,12 @@ TEST(Path, 3) {
       {"/a/bbb", lc},
   };
   std::string request = "/a/bbb/abc.html";
-  EXPECT_THROW(Path::FindBestLocation(mapList, request),
-               LocationNotFound);
+  std::string expected =
+      "/usr/local/www/nginx/"
+      "/abc.html";
+  std::string path =
+      Path::GetAliasPath(Path::FindBestLocation(mapList, request), request);
+  EXPECT_EQ(expected, path);
 }
 
 TEST(Path, 4) {
@@ -48,8 +52,12 @@ TEST(Path, 4) {
       {"/kapounet", lc},
   };
   std::string request = "/kapounet/pouic/toto/pounet.html";
-  EXPECT_THROW(Path::FindBestLocation(mapList, request),
-               LocationNotFound);
+  std::string expected =
+      "/tmp/www/"
+      "/pouic/toto/pounet.html";
+  std::string path =
+      Path::GetAliasPath(Path::FindBestLocation(mapList, request), request);
+  EXPECT_EQ(expected, path);
 }
 
 TEST(Path, 5) {
@@ -72,8 +80,12 @@ TEST(Path, 6) {
       {"/kapounet", lc},
   };
   std::string request = "/kapounet/pouic/toto/pounet.html";
-  EXPECT_THROW(Path::FindBestLocation(mapList, request),
-               LocationNotFound);
+  std::string expected =
+      "/tmp/www/"
+      "/pouic/toto/pounet.html";
+  std::string path =
+      Path::GetAliasPath(Path::FindBestLocation(mapList, request), request);
+  EXPECT_EQ(expected, path);
 }
 
 TEST(Path, 7) {
@@ -84,8 +96,12 @@ TEST(Path, 7) {
       {"/kapounet/pouic", lc},
   };
   std::string request = "/kapounet/pouic/toto/pounet.html";
-  EXPECT_THROW(Path::FindBestLocation(mapList, request),
-               LocationNotFound);
+  std::string expected =
+      "/tmp/www/"
+      "/toto/pounet.html";
+  std::string path =
+      Path::GetAliasPath(Path::FindBestLocation(mapList, request), request);
+  EXPECT_EQ(expected, path);
 }
 
 TEST(Path, 8) {
@@ -122,8 +138,8 @@ TEST(Path, exact_match) {
   lc1.root = "/ok";  // match
   lc2.root = "/ng";
   Locationmap mapList = {
-      {"/images", lc1},  // ok
-      {"/", lc2},        // ng
+      {"/images", lc1},  // ok(longest)
+      {"/", lc2},        // ok
   };
 
   std::string request_uri = "/images";
@@ -136,13 +152,13 @@ TEST(Path, exact_match2) {
   lc1.root = "/ng";
   lc2.root = "/ok";  // match
   Locationmap mapList = {
-      {"/images", lc1},  // ng
       {"/", lc2},        // ok
+      {"/images", lc1},  // ok(longest)
   };
 
   std::string request_uri = "/images/index.html";
   LocationPair lp = Path::FindBestLocation(mapList, request_uri);
-  EXPECT_EQ(lc2.root, lp.second.root);
+  EXPECT_EQ(lc1.root, lp.second.root);
 }
 
 TEST(Path, exact_match3) {
@@ -150,13 +166,13 @@ TEST(Path, exact_match3) {
   lc1.root = "/ok";  // match
   lc2.root = "/ng";
   Locationmap mapList = {
-      {"/images", lc1},  // ng
+      {"/images", lc1},  // ok(longest)
       {"/", lc2},        // ok
   };
 
   std::string request_uri = "/images/";
   LocationPair lp = Path::FindBestLocation(mapList, request_uri);
-  EXPECT_EQ(lc2.root, lp.second.root);
+  EXPECT_EQ(lc1.root, lp.second.root);
 }
 
 TEST(Path, exact_match4) {
@@ -194,9 +210,9 @@ TEST(PATH, exact_match5) {
 TEST(PATH, longest_match1) {
   LocationContext lc1, lc2, lc3;
   Locationmap mapList = {
+      {"/images/a", lc3},  // ng
       {"/", lc1},          // ng
       {"/images/", lc2},   // ok
-      {"/images/a", lc3},  // ng
   };
 
   std::string request_uri = "/images/abcdef";
@@ -207,9 +223,9 @@ TEST(PATH, longest_match1) {
 TEST(PATH, longest_match2) {
   LocationContext lc1, lc2, lc3;
   Locationmap mapList = {
+      {"/images/abcdefg", lc3},  // ng
       {"/", lc1},                // ng
       {"/images/", lc2},         // ok
-      {"/images/abcdefg", lc3},  // ng
   };
 
   std::string request_uri = "/images/abcdef";
@@ -220,10 +236,10 @@ TEST(PATH, longest_match2) {
 TEST(PATH, longest_match3) {
   LocationContext lc1, lc2, lc3, lc4;
   Locationmap mapList = {
+      {"/images/png/", lc4},  // ok
       {"/", lc1},             // ng
       {"/images/", lc2},      // ng
       {"/images/jpg/", lc3},  // ng
-      {"/images/png/", lc4},  // ok
   };
 
   std::string request_uri = "/images/png/abcdef";


### PR DESCRIPTION

Closes #109 



```
location /hoge {
  root /var/www/html/xxx/;
}
``` 
のような設定で動いている webserv に対し、
`GET /hogefuga` のようなリクエストを送信すると

## before

問答無用で404

## after

`/hogefuga` のうち、matchする `/hoge` の部分が `/var/www/html/xxx/` に置換されるため、
aliasの結果 `/var/www/html/xxx/fuga` にアクセスしたことになる