### PR TITLE
limit_except の修正

### DIFF
--- a/srcs/Config/Parser.cpp
+++ b/srcs/Config/Parser.cpp
@@ -146,8 +146,8 @@ void Parser::StoreLocation(ServerContext *sc) {
 void Parser::StoreLimitExcept(LocationContext *lc) {
   Token tkn = tkns_.Next();
   do {
-    if (tkn.GetData() == "kDelete" || tkn.GetData() == "kGet" ||
-        tkn.GetData() == "kPost") {
+    if (tkn.GetData() == "DELETE" || tkn.GetData() == "GET" ||
+        tkn.GetData() == "POST") {
       if (lc->limit_except.find(tkn.GetData()) != lc->limit_except.end())
         throw ConfigErrException("`limit_except` directive is duplicate", tkn);
       lc->limit_except.insert(tkn.GetData());

--- a/srcs/Utils/Utils.cpp
+++ b/srcs/Utils/Utils.cpp
@@ -121,7 +121,7 @@ std::string ConvertTimeToString(const time_t &time) {
 }
 
 std::string GetCurrentDate() {
-  time_t rawtime;
+  time_t rawtime = 0;
 
   time(&rawtime);
 


### PR DESCRIPTION
`limit_except` の制約に違反したとき、 nginx は 403 を返しているように見える
ただ、自分の手元の設定が悪い可能性があるため一旦skip